### PR TITLE
Logfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,21 @@ particular event that happened during the execution of the program, while
 the rest of the arguments are the properties of this event.
 
 From these logging statements, Chronicles can be configured to produce log
-output in various structured formats. The default format is called `textblocks`
+output in various structured formats. The default format is called `logfmt`
 and it looks like this:
+
+```
+time="2018-08-22 20:01:58" level=INFO msg="New incoming connection" thread=0 remoteAddr=192.168.1.2 remotePort=26532
+`
+Chronicles also supports a format called `textblocks`, as seen in this
+example:
+``
 
 ![textblocks format example](media/textblocks.svg)
 
 Alternatively, you can use another human-readable format called `textlines`:
 
 ![textblocks format example](media/textlines.svg)
-
-Chronicles also supports [logfmt](https://brandur.org/logfmt), as seen in this
-example:
-
-```
-time="2018-08-22 20:01:58" level=INFO msg="New incoming connection" thread=0 remoteAddr=192.168.1.2 remotePort=26532
-```
 
 While these human-readable formats provide a more traditional and familiar
 experience of using a logging library, the true power of Chronicles is

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Alternatively, you can use another human-readable format called `textlines`:
 
 ![textblocks format example](media/textlines.svg)
 
+Chronicles also supports [logfmt](https://brandur.org/logfmt), as seen in this
+example:
+
+```
+time="2018-08-22 20:01:58" level=INFO msg="New incoming connection" thread=0 remoteAddr=192.168.1.2 remotePort=26532
+```
+
 While these human-readable formats provide a more traditional and familiar
 experience of using a logging library, the true power of Chronicles is
 unlocked only after switching to the `JSON` format. Then, the same log output
@@ -377,7 +384,7 @@ Possible values are:
   application in older versions of Windows. On Unix-like systems, ANSI codes
   are still used.
 
-- `AnsiColors` 
+- `AnsiColors`
 
   Output suitable for terminals supporting the standard ANSI escape codes:
   https://en.wikipedia.org/wiki/ANSI_escape_code

--- a/chronicles/options.nim
+++ b/chronicles/options.nim
@@ -292,5 +292,5 @@ const
 
   config* = when chronicles_streams.len > 0: parseStreamsSpec(chronicles_streams)
             elif chronicles_sinks.len > 0:   parseSinksSpec(chronicles_sinks)
-            else: parseSinksSpec "textblocks"
+            else: parseSinksSpec "logFmt"
 

--- a/chronicles/options.nim
+++ b/chronicles/options.nim
@@ -42,6 +42,7 @@ type
 
   LogFormat* = enum
     json,
+    logFmt,
     textLines,
     textBlocks
 
@@ -131,6 +132,8 @@ proc logFormatFromIdent(n: NimNode): LogFormat =
   case format.toLowerAscii
   of "json":
     return json
+  of "logfmt":
+    return logFmt
   of "textlines":
     return textLines
   of "textblocks":


### PR DESCRIPTION
To understand the code a little better, wrote an additional formatter that uses https://brandur.org/logfmt - some advantages are:

* full key-value format that can be parsed easily but remains human-accessible: https://blog.codeship.com/logfmt-a-log-format-thats-easy-to-read-and-write/
* compatible with several other logging libraries and tools, for example https://github.com/rokett/LogRouter, https://www.npmjs.com/package/logfmt and several others, making it easy to integrate with existing logging solutions.
* handy utilities exist already: https://github.com/brandur/hutils

The first commit adds the support, the second commit changes it to be the default. This has the following advantages:
* single-line - opens up the log output to standard text processing tools (grep, sed etc)
* delimited by newline - when streaming to a log service, it can distingish separate events
* compact - the blocks format, on a typical terminal, will fit very few log lines making it hard to get an overview
