### PR TITLE
Log polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ particular event that happened during the execution of the program, while
 the rest of the arguments are the properties of this event.
 
 From these logging statements, Chronicles can be configured to produce log
-output in various structured formats. The default format is called `textblocks`
+output in various structured formats. The default format is called `textlines`
 and it looks like this:
 
-![textblocks format example](media/textblocks.svg)
-
-Alternatively, you can use another human-readable format called `textlines`:
-
 ![textblocks format example](media/textlines.svg)
+
+Alternatively, you can use a multi-line format called `textblocks`:
+
+![textblocks format example](media/textblocks.svg)
 
 While these human-readable formats provide a more traditional and familiar
 experience of using a logging library, the true power of Chronicles is
@@ -377,7 +377,7 @@ Possible values are:
   application in older versions of Windows. On Unix-like systems, ANSI codes
   are still used.
 
-- `AnsiColors` 
+- `AnsiColors`
 
   Output suitable for terminals supporting the standard ANSI escape codes:
   https://en.wikipedia.org/wiki/ANSI_escape_code

--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -293,14 +293,22 @@ template levelToStyle(lvl: LogLevel): untyped =
   of FATAL: (fgRed, true)
   of NONE:  (fgWhite, false)
 
+template shortName(lvl: LogLevel): string =
+  # Same-length strings make for nice alignment
+  case lvl
+  of DEBUG: "DBG"
+  of INFO:  "INF"
+  of NOTICE:"NOT"
+  of WARN:  "WRN"
+  of ERROR: "ERR"
+  of FATAL: "FAT"
+  of NONE:  "   "
+
 template appendLogLevelMarker(r: var auto, lvl: LogLevel, align: bool) =
   let (color, bright) = levelToStyle(lvl)
   let lvlString =
-    if align:
-      # using 4 characters for level brings it down to an acceptable
-      ($lvl)[0..3]
-    else:
-      $lvl
+    if align: shortName(lvl)
+    else: $lvl
   fgColor(r, color, bright)
   append(r.output, $lvlString)
   resetColors(r)
@@ -470,7 +478,7 @@ template initLogRecord*(r: var JsonRecord,
                    """, "lvl": """ & jsonEncode($lvl))
 
   if topics.len > 0:
-    append(r.output, """, "topics": """ &  jsonEncode(topics))
+    append(r.output, """, "topics": """ & jsonEncode(topics))
 
   when r.timestamps != NoTimestamps:
     append(r.output, """, "ts": """")

--- a/chronicles/options.nim
+++ b/chronicles/options.nim
@@ -289,5 +289,8 @@ const
 
   config* = when chronicles_streams.len > 0: parseStreamsSpec(chronicles_streams)
             elif chronicles_sinks.len > 0:   parseSinksSpec(chronicles_sinks)
-            else: parseSinksSpec "textblocks"
+            # default is textlines - single-line format is good for interop with
+            # text processing tools like grep and logstash, good use of screen
+            # real estate
+            else: parseSinksSpec "textlines"
 

--- a/chronicles/options.nim
+++ b/chronicles/options.nim
@@ -289,8 +289,17 @@ const
 
   config* = when chronicles_streams.len > 0: parseStreamsSpec(chronicles_streams)
             elif chronicles_sinks.len > 0:   parseSinksSpec(chronicles_sinks)
-            # default is textlines - single-line format is good for interop with
-            # text processing tools like grep and logstash, good use of screen
-            # real estate
+            # default is textlines because:
+            # * better compatibility with typical log processing tools
+            #   like grep, logstash etc where newline delieates events or units
+            # * easier to match with a regex
+            # * good use of screen real estate
+            # * wins nimbus developer straw poll
+            # alternatively, one could prefer to use "textblocks" - it can be
+            # enabled by passing -d:chronicles_sinks=textblocks
+            # * some tools understand that indented lines following newline
+            #   "belong" to the same logging eevent
+            # * wrapping more likely to happen making line hard to read on
+            #   narrow terminals
+            # * properies may be easier to find
             else: parseSinksSpec "textlines"
-

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,1 +1,31 @@
+import chronicles, strutils, unittest
 
+
+type TestOutput = object
+
+# XXX would be nicer to use something akin to a mock to verify this but 30s of
+#     searching didn't reveal anything
+var v: string
+
+customLogStream s[TextLineRecord[TestOutput, NoTimestamps, NoColors]]
+
+template append*(o: var TestOutput, s: string) = v.add(s)
+template flushOutput*(o: var TestOutput)       = discard
+
+suite "textlines":
+  setup:
+    v = ""
+
+  test "should quote space":
+    s.debug "test", yes = "quote me", no = "noquote"
+
+    check "yes=\"quote me\"" in v
+    check "no=noquote" in v
+
+    test "should escape newlines space lines":
+      const multiline = """quote
+me"""
+
+      s.debug "test", s = multiline
+
+      check "s=\"quote\\nme\"" in v


### PR DESCRIPTION
* use textlines by default
* fixed-width level, time and message makes for nice columns
* colorize keys according to log level
* remove brackets around stuff (already conveyed by columns)
* quote values with spaces in them (like logfmt, allows parsing k/v
easily

```
INFO 2018-08-24 11:33:06 long info                                  thread=0 str="some multiline\nstring\nmore lines"
WARN 2018-08-24 11:33:06 long warning                               thread=0 str="some multiline\nstring\nmore lines"
INFO 2018-08-24 11:33:06 long info
  thread: 0
  str: some multiline
       string
       more lines
       
WARN 2018-08-24 11:33:06 long warning
  thread: 0
  str: some multiline
       string
       more lines
       

```