### PR TITLE
Feature/logfilters 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,14 @@ proc setLogLevel*(level: LogLevel)
 type TopicState = enum
   Normal, Enabled, Required, Disabled
 
-proc setTopicState*(topicName: string, state: TopicState): bool
+proc setTopicState*(name: string,
+                    newState: TopicState,
+                    logLevel = LogLevel.NONE): bool
 ```
+
+It is also possible for a specific topic to overrule the global `LogLevel`, set
+by `setLogLevel`, by setting the optional `logLevel` parameter in
+`setTopicState` to a valid `LogLevel`.
 
 The option is disabled by default because we recommend filtering the
 log output in a tailing program. This allows you to still look at all

--- a/README.md
+++ b/README.md
@@ -295,6 +295,13 @@ When the list includes multiple topics, any of them is considered a match.
 > In both contexts, the list of topics is written as a comma or space-separated
 string of case-sensitive topic names.
 
+In the list of topics, you can also optionally provide a log level after the
+topic, separated with a colon from the topic. If a log level is provided it will
+overrule the `chronicles_log_level` setting. The log level can be defined as
+`LogLevel` values or directly as the corresponding integer values.
+
+e.g. `-d:chronicles_enabled_topics:MyTopic:DEBUG,AnotherTopic:5`
+
 ### chronicles_required_topics
 
 Similar to `chronicles_enabled_topics`, but requires the logging statements

--- a/chronicles/options.nim
+++ b/chronicles/options.nim
@@ -33,14 +33,14 @@ when chronicles_streams.len > 0 and chronicles_sinks.len > 0:
 
 type
   LogLevel* = enum
+    NONE,
     TRACE,
     DEBUG,
     INFO,
     NOTICE,
     WARN,
     ERROR,
-    FATAL,
-    NONE
+    FATAL
 
   LogFormat* = enum
     json,
@@ -88,7 +88,7 @@ type
   Configuration* = object
     streams*: seq[StreamSpec]
 
-  Topic* = object
+  EnabledTopic* = object
     name*: string
     logLevel*: LogLevel
 
@@ -132,21 +132,22 @@ template topicsAsSeq(topics: string): untyped =
   else:
     newSeq[string](0)
 
-template topicsWithLogLevelAsSeq(topics: string): untyped =
-  var sequence = newSeq[Topic](0)
-  when topics.len > 0:
+proc topicsWithLogLevelAsSeq(topics: string): untyped =
+  var sequence = newSeq[EnabledTopic](0)
+  if topics.len > 0:
     for topic in split(topics, {','} + Whitespace):
       var values = topic.split(':')
       if values.len > 1:
         if values[1].isDigit:
-          sequence.add(Topic(name: values[0],
-                             logLevel: LogLevel(parseInt(values[1]))))
+          sequence.add(EnabledTopic(name: values[0],
+                                    logLevel: LogLevel(parseInt(values[1]))))
         else:
-          sequence.add(Topic(name: values[0],
-                             logLevel: handleEnumOption(LogLevel, values[1])))
+          sequence.add(EnabledTopic(name: values[0],
+                                    logLevel: handleEnumOption(LogLevel,
+                                                               values[1])))
       else:
-        sequence.add(Topic(name: values[0], logLevel: None))
-  sequence
+        sequence.add(EnabledTopic(name: values[0], logLevel: NONE))
+  return sequence
 
 proc logFormatFromIdent(n: NimNode): LogFormat =
   let format = $n

--- a/chronicles/topics_registry.nim
+++ b/chronicles/topics_registry.nim
@@ -24,7 +24,7 @@ var registry* = initTopicsRegistry()
 
 iterator topicStates*: (string, TopicState) =
   for name, topic in registry.topicStatesTable:
-    yield (name, topic[].state)
+    yield (name, topic.state)
 
 proc registerTopic*(name: string, topic: ptr Topic): ptr Topic =
   registry.topicStatesTable[name] = topic
@@ -38,7 +38,7 @@ proc setTopicState*(name: string,
 
   var topicPtr = registry.topicStatesTable[name]
 
-  case topicPtr[].state
+  case topicPtr.state
   of Enabled: dec registry.totalEnabledTopics
   of Required: dec registry.totalRequiredTopics
   else: discard
@@ -48,7 +48,7 @@ proc setTopicState*(name: string,
   of Required: inc registry.totalRequiredTopics
   else: discard
 
-  topicPtr[].state = newState
-  topicPtr[].logLevel = logLevel
+  topicPtr.state = newState
+  topicPtr.logLevel = logLevel
 
   return true

--- a/tests/runtime_filtering.nim
+++ b/tests/runtime_filtering.nim
@@ -62,3 +62,27 @@ echo setTopicState("bar", Normal)
 foo()
 bar()
 
+echo "> set main to WARN, none should print:"
+echo setTopicState("main", Normal, WARN)
+echo setTopicState("foo", Normal)
+echo setTopicState("bar", Normal)
+
+foo()
+bar()
+
+echo "> set foo to INFO, main back to default, foo should print:"
+echo setTopicState("main", Normal)
+echo setTopicState("foo", Normal, INFO)
+echo setTopicState("bar", Normal, WARN)
+
+foo()
+bar()
+
+echo "> set global LogLevel to WARN, set main and foo to INFO, foo should print:"
+setLogLevel(WARN)
+echo setTopicState("main", Normal, INFO)
+echo setTopicState("foo", Normal, INFO)
+echo setTopicState("bar", Normal)
+
+foo()
+bar()


### PR DESCRIPTION
Here is a first proposal for #17. I say first, as I feel there will be iterations ;)

Some items I came across during development:
- The documentation mentions that the topics are comma- or space-separated lists (both in context of compile time option as for logScope or log statement).
 Currently this was not the case. I added comma in both contexts. If this is not wanted, we should update the documentation.
- chronicles_enabled_topics and chronicles_required_topics is probably something you will not use together. However they are accepted together, basically creating non working behaviour for both if you do so. This was adjusted somewhat with this PR but it all still depends on what is wanted in this situation. Perhaps just not allow both?
- In chronicles_enabled_topics the log level is allowed to be the enum values or its corresponding integer values.
  - I question if these integer values are so useful. If they would map on the levels of syslog/kernel or some other well known numbers perhaps, but as is?
  - I could have added the digit checking also in the handleEnumOption proc directly, but that would have as (I believe) unwanted side-effect that other enum options could also be set with their int values.

In general, I also believe the compile time commit could be more clean, however I think that will need a bigger code overhaul. Hence, I await a second opinion. :)
