### PR TITLE
Format unix timestamp decimals always to 6

### DIFF
--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -292,7 +292,7 @@ template writeTs(record) =
   when record.timestamps == RfcTime:
     appendRfcTimestamp(record.output)
   else:
-    append(record.output, $epochTime())
+    append(record.output, formatFloat(epochTime(), ffDecimal, 6))
 
 const
   propColor = if defined(windows): fgCyan else: fgBlue


### PR DESCRIPTION
Currently the unix timestamp will show different formatting depending on the zeros at end. 
PR to format it always to 6 digits after decimal.