### PR TITLE
"<log>Exception" templates that inject exception info

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -261,8 +261,8 @@ template log*(stream: type,
   logIMPL(instantiationInfo(), stream, stream.Record, eventName, severity,
           bindSym("activeChroniclesScope", brForceOpen), props)
 
-template logFn(name, severity) {.dirty.} =
-  template `name`*(eventName: static[string],
+template logFn(fnName, severity) {.dirty.} =
+  template `fnName`*(eventName: static[string],
                    props: varargs[untyped]) {.dirty.} =
 
     bind logIMPL, bindSym, brForceOpen
@@ -270,13 +270,30 @@ template logFn(name, severity) {.dirty.} =
             activeChroniclesStream().Record, eventName, severity,
             bindSym("activeChroniclesScope", brForceOpen), props)
 
-  template `name`*(stream: type,
+  template `fnName Exception`*(eventName: static[string],
+                   props: varargs[untyped]) =
+    let exc = getCurrentException()
+    logScope:
+      exception = exc.name
+      exceptionMessage = exc.msg
+    `fnName`(eventName, props)
+
+  template `fnName`*(stream: type,
                    eventName: static[string],
                    props: varargs[untyped])  {.dirty.} =
 
     bind logIMPL, bindSym, brForceOpen
     logIMPL(instantiationInfo(), stream, stream.Record, eventName, severity,
             bindSym("activeChroniclesScope", brForceOpen), props)
+
+  template `fnName Exception`*(stream: type,
+                   eventName: static[string],
+                   props: varargs[untyped]) =
+    let exc = getCurrentException()
+    logScope:
+      exception = exc.name
+      exceptionMessage = exc.msg
+    `fnName`(stream, eventName, props)
 
 logFn trace , LogLevel.TRACE
 logFn debug , LogLevel.DEBUG

--- a/tests/exceptions.nim
+++ b/tests/exceptions.nim
@@ -1,0 +1,14 @@
+import chronicles
+
+type CustomException = object of Exception
+
+logStream lines[textlines]
+
+try:
+  raise newException(CustomException, "custom message")
+except:
+  debug "test debug", foo="bar"
+  debugException "test debugException", foo="bar"
+  errorException "test errorException"
+  lines.warnException "test warnException stream"
+

--- a/tests/other/exceptions.test
+++ b/tests/other/exceptions.test
@@ -1,0 +1,11 @@
+program=exceptions
+chronicles_sinks="textlines[stdout]"
+chronicles_colors=None
+chronicles_timestamps=None
+
+[Output]
+stdout="""DBG test debug                                 thread=0 foo=bar
+DBG test debugException                        thread=0 exception=CustomException exceptionMessage="custom message" foo=bar
+ERR test errorException                        thread=0 exception=CustomException exceptionMessage="custom message"
+WRN test warnException stream                  thread=0 exception=CustomException exceptionMessage="custom message"
+"""

--- a/tests/testrunner.nim
+++ b/tests/testrunner.nim
@@ -174,7 +174,7 @@ proc scanTestPath(path: string): seq[string] =
     result.add(path)
   else:
     for file in walkDirRec path:
-      if file.match re".*\.test":
+      if file.match re".*\.test$":
         result.add(file)
 
 proc test(config: TestConfig, testPath: string): TestStatus =


### PR DESCRIPTION
(and a more precise regex for "*.test" file scanning)

Rationale - it would help us simplify most of these cases:
```
../nim-json-rpc/json_rpc/router.nim:73:    msg = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/router.nim:188:    let msg = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/clients/httpclient.nim:114:          error = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/clients/httpclient.nim:154:          error = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/servers/httpserver.nim:133:            error = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/servers/httpserver.nim:167:              error = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/servers/httpserver.nim:213:                                     message = getCurrentExceptionMsg()
../nim-json-rpc/json_rpc/servers/socketserver.nim:39:    error "Failed to create server", address = $address, message = getCurrentExceptionMsg()
../nim-json-rpc/tests/testerrors.nim:55:      echo "Error ", getCurrentExceptionMsg()
../nim-json-rpc/tests/testerrors.nim:63:      echo "Error ", getCurrentExceptionMsg()
../nim-json-rpc/tests/testerrors.nim:70:      echo "Error ", getCurrentExceptionMsg()
../nim-json-rpc/tests/testerrors.nim:79:      echo "Error ", getCurrentExceptionMsg()
../asyncdispatch2/asyncdispatch2/asyncmacro2.nim:61:        retFutureSym.fail(getCurrentException())
../asyncdispatch2/asyncdispatch2/transports/common.nim:232:        raise newException(TransportAddressError, getCurrentException().msg)
../asyncdispatch2/asyncdispatch2/transports/common.nim:250:    raise newException(TransportAddressError, getCurrentException().msg)
../nim-chronicles-tail/ctail.nim:397:      print "Error: " & getCurrentExceptionMsg()
../nim-chronicles-tail/ctail.nim:416:      print "Error: " & getCurrentExceptionMsg()
../nim-chronicles-tail/ctail.nim:487:    let ex = getCurrentException()
../nimbus/nimbus/vm/interpreter_dispatch.nim:259:    computation.error = Error(info: getCurrentExceptionMsg())
../nimbus/nimbus/vm/interpreter_dispatch.nim:260:    debug "executeOpcodes() failed", error = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/peer_pool.nim:174:            err = getCurrentExceptionMsg(),
../eth_p2p/eth_p2p/discovery.nim:255:    debug "receive failed", exception = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx_protocols/les/flow_control.nim:123:            err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/blockchain_sync.nim:168:      exc = getCurrentException().name,
../eth_p2p/eth_p2p/blockchain_sync.nim:169:      err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/blockchain_sync.nim:217:            exc = getCurrentException().name,
../eth_p2p/eth_p2p/blockchain_sync.nim:218:            err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/blockchain_sync.nim:322:      exc = getCurrentException().name,
../eth_p2p/eth_p2p/blockchain_sync.nim:323:      err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx.nim:211:          exc = getCurrentException().name,
../eth_p2p/eth_p2p/rlpx.nim:212:          err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx.nim:472:            exception = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx.nim:525:      debug "ending dispatchMessages loop", peer, err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx.nim:1353:    trace "TransportOsError", err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx.nim:1356:          exc = getCurrentException().name,
../eth_p2p/eth_p2p/rlpx.nim:1357:          err = getCurrentExceptionMsg()
../eth_p2p/eth_p2p/rlpx.nim:1425:    let e = getCurrentException()
../eth_p2p/eth_p2p/rlpx.nim:1427:          err = getCurrentExceptionMsg(),
../eth_p2p/eth_p2p/rlpx.nim:1428:          stackTrace = getCurrentException().getStackTrace()
../json_rpc/json_rpc/router.nim:73:    msg = getCurrentExceptionMsg()
../json_rpc/json_rpc/router.nim:188:    let msg = getCurrentExceptionMsg()
../json_rpc/json_rpc/clients/httpclient.nim:114:          error = getCurrentExceptionMsg()
../json_rpc/json_rpc/clients/httpclient.nim:154:          error = getCurrentExceptionMsg()
../json_rpc/json_rpc/servers/httpserver.nim:133:            error = getCurrentExceptionMsg()
../json_rpc/json_rpc/servers/httpserver.nim:167:              error = getCurrentExceptionMsg()
../json_rpc/json_rpc/servers/httpserver.nim:213:                                     message = getCurrentExceptionMsg()
../json_rpc/json_rpc/servers/socketserver.nim:39:    error "Failed to create server", address = $address, message = getCurrentExceptionMsg()
../json_rpc/tests/testerrors.nim:55:      echo "Error ", getCurrentExceptionMsg()
../json_rpc/tests/testerrors.nim:63:      echo "Error ", getCurrentExceptionMsg()
../json_rpc/tests/testerrors.nim:70:      echo "Error ", getCurrentExceptionMsg()
../json_rpc/tests/testerrors.nim:79:      echo "Error ", getCurrentExceptionMsg()
```
