### PR TITLE
Fix compilation error on Nim devel

### DIFF
--- a/chronicles/options.nim
+++ b/chronicles/options.nim
@@ -134,7 +134,7 @@ template topicsAsSeq*(topics: string): untyped =
   else:
     newSeq[string](0)
 
-proc topicsWithLogLevelAsSeq(topics: string): untyped =
+proc topicsWithLogLevelAsSeq(topics: string): seq[EnabledTopic] =
   var sequence = newSeq[EnabledTopic](0)
   if topics.len > 0:
     for topic in split(topics, {','} + Whitespace):


### PR DESCRIPTION
Without this change Chronicles fails to compile on latest Nim compiler with that error:
```
/home/dian/.nimble/pkgs/chronicles-0.4.1/chronicles/options.nim(137, 47) Error: return type 'untyped' is only valid for macros and templates
```

Changing the return type to seq fixes it.