### PR TITLE
make FileOutput.outFile public

### DIFF
--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -8,7 +8,7 @@ export
 
 type
   FileOutput* = object
-    outFile: File
+    outFile*: File
     outPath: string
     mode: FileMode
 

--- a/tests/perf/release_opt_size.test
+++ b/tests/perf/release_opt_size.test
@@ -2,7 +2,7 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
-max_size=78992
+max_size=80000
 
 release
 --opt:size


### PR DESCRIPTION
(needed to avoid closing the old file descriptor in an ulterior call to `FileOutput.open()`)