### PR TITLE
replace a getCurrentExceptionMsg() instance

### DIFF
--- a/tests/testrunner.nim
+++ b/tests/testrunner.nim
@@ -200,8 +200,8 @@ proc test(config: TestConfig, testPath: string): TestStatus =
     try:
       # this may fail in 64-bit AppVeyor images with "The process cannot access the file because it is being used by another process. [OSError]"
       removeFile(test.program.addFileExt(ExeExt))
-    except:
-      echo getCurrentExceptionMsg()
+    except CatchableError as e:
+      echo e.msg
 
   logResult(test.name, result, duration)
 


### PR DESCRIPTION
Some of the test suite seems broken with Nim-1.0.4, but it's not related to this PR.