### PR TITLE
Don't sort the logged properties (close #22)

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -229,13 +229,11 @@ macro logIMPL(lineInfo: static InstInfo,
   let lexicalBindings = scopes.finalLexicalBindings
   var finalBindings = initOrderedTable[string, NimNode]()
 
-  for k, v in assignments(lexicalBindings, acLogStatement):
-    finalBindings[k] = v
-
   for k, v in assignments(logStmtBindings, acLogStatement):
     finalBindings[k] = v
 
-  finalBindings.sort do (lhs, rhs: auto) -> int: cmp(lhs[0], rhs[0])
+  for k, v in assignments(lexicalBindings, acLogStatement):
+    finalBindings[k] = v
 
   # This is the compile-time topic filtering code, which has a similar
   # logic to the generated run-time filtering code:

--- a/tests/loglevel/info_level.test
+++ b/tests/loglevel/info_level.test
@@ -3,14 +3,13 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=INFO
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF after main                                 topics="general" tid=0
-INF exiting                                    tid=0 msg="bye bye"
+stdout="""WRN inside main                                topics="main" tid=26862 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26862 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26862 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26862 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26862 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26862 b=10 arg=20
+INF after main                                 topics="general" tid=26862
+INF exiting                                    tid=26862 msg="bye bye"
 """

--- a/tests/loglevel/no_level.test
+++ b/tests/loglevel/no_level.test
@@ -3,17 +3,16 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=NONE
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-DBG inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-DBG inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF after main                                 topics="general" tid=0
-INF exiting                                    tid=0 msg="bye bye"
+stdout="""WRN inside main                                topics="main" tid=26900 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26900 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26900 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26900 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26900 b=10 arg=10
+DBG inside foo                                 topics="foo" tid=26900 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26900 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26900 b=10 arg=20
+DBG inside foobar                              topics="foo bar" tid=26900 b=10 arg=20
+INF after main                                 topics="general" tid=26900
+INF exiting                                    tid=26900 msg="bye bye"
 """

--- a/tests/loglevel/release_build_level.test
+++ b/tests/loglevel/release_build_level.test
@@ -2,16 +2,14 @@ program=topics_and_loglvls
 chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 release
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF after main                                 topics="general" tid=0
-INF exiting                                    tid=0 msg="bye bye"
+stdout="""WRN inside main                                topics="main" tid=26907 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26907 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26907 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26907 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26907 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26907 b=10 arg=20
+INF after main                                 topics="general" tid=26907
+INF exiting                                    tid=26907 msg="bye bye"
 """

--- a/tests/loglevel/topic_log_level1.test
+++ b/tests/loglevel/topic_log_level1.test
@@ -4,12 +4,11 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
 chronicles_enabled_topics="foo:WARN,bar:INFO,main"
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26843 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26843 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26843 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26843 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26843 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26843 b=10 arg=20
 """

--- a/tests/loglevel/topic_log_level2.test
+++ b/tests/loglevel/topic_log_level2.test
@@ -4,13 +4,12 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
 chronicles_enabled_topics="foo:INFO,bar:WARN,main"
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26832 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26832 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26832 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26832 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26832 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26832 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26832 b=10 arg=20
 """

--- a/tests/loglevel/topic_log_level3.test
+++ b/tests/loglevel/topic_log_level3.test
@@ -4,10 +4,9 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=WARN
 chronicles_enabled_topics="foo:WARN,bar:INFO,main"
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26927 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26927 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26927 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26927 b=10 arg=20
 """

--- a/tests/loglevel/topic_log_level4.test
+++ b/tests/loglevel/topic_log_level4.test
@@ -4,11 +4,10 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=WARN
 chronicles_enabled_topics="foo:INFO,bar:WARN,main"
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26881 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26881 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26881 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26881 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26881 b=10 arg=20
 """

--- a/tests/loglevel/topic_log_level_none.test
+++ b/tests/loglevel/topic_log_level_none.test
@@ -4,9 +4,8 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=WARN
 chronicles_enabled_topics="foo:0,main:NONE"
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26956 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26956 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26956 b=10 arg=20
 """

--- a/tests/loglevel/topic_log_level_number.test
+++ b/tests/loglevel/topic_log_level_number.test
@@ -4,13 +4,12 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=WARN
 chronicles_enabled_topics="foo:3,bar:WARN,main:2"
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26939 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26939 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26939 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26939 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26939 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26939 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26939 b=10 arg=20
 """

--- a/tests/loglevel/warn_level.test
+++ b/tests/loglevel/warn_level.test
@@ -3,9 +3,8 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=WARN
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26819 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26819 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26819 b=10 arg=20
 """

--- a/tests/other/indent.test
+++ b/tests/other/indent.test
@@ -3,24 +3,23 @@ chronicles_sinks="textblocks[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_indent=1
-
 [Output]
 stdout="""INF main started topics="main"
- tid: 0
- a: 10
- arg: 50
- b: inner-b
- c: 10
- d: some-d
- x: 16
- z: 20
-
-INF exiting
- tid: 0
+ tid: 26603
  a: 12
  b: overriden-b
- c: 100
- msg: bye bye
+ d: some-d
+ arg: 50
+ z: 20
  x: 16
+ c: 10
+
+INF exiting
+ tid: 26603
+ msg: bye bye
+ b: overriden-b
+ x: 16
+ c: 100
+ a: 12
 
 """

--- a/tests/other/line_numbers.test
+++ b/tests/other/line_numbers.test
@@ -3,17 +3,16 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_line_numbers=on
-
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 file=topics_and_loglvls.nim:9 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 file=topics_and_loglvls.nim:10 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 file=topics_and_loglvls.nim:11 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 file=topics_and_loglvls.nim:18 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 file=topics_and_loglvls.nim:19 arg=10 b=10
-DBG inside foo                                 topics="foo" tid=0 file=topics_and_loglvls.nim:20 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 file=topics_and_loglvls.nim:27 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 file=topics_and_loglvls.nim:28 arg=20 b=10
-DBG inside foobar                              topics="foo bar" tid=0 file=topics_and_loglvls.nim:29 arg=20 b=10
-INF after main                                 topics="general" tid=0 file=topics_and_loglvls.nim:35
-INF exiting                                    tid=0 file=topics_and_loglvls.nim:36 msg="bye bye"
+stdout="""WRN inside main                                topics="main" tid=26560 file=topics_and_loglvls.nim:9 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26560 file=topics_and_loglvls.nim:10 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26560 file=topics_and_loglvls.nim:11 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26560 file=topics_and_loglvls.nim:18 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26560 file=topics_and_loglvls.nim:19 b=10 arg=10
+DBG inside foo                                 topics="foo" tid=26560 file=topics_and_loglvls.nim:20 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26560 file=topics_and_loglvls.nim:27 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26560 file=topics_and_loglvls.nim:28 b=10 arg=20
+DBG inside foobar                              topics="foo bar" tid=26560 file=topics_and_loglvls.nim:29 b=10 arg=20
+INF after main                                 topics="general" tid=26560 file=topics_and_loglvls.nim:35
+INF exiting                                    tid=26560 file=topics_and_loglvls.nim:36 msg="bye bye"
 """

--- a/tests/sinks/custom_file_nocolors.test
+++ b/tests/sinks/custom_file_nocolors.test
@@ -1,8 +1,7 @@
 program=lexical_scopes
 chronicles_sinks="textlines[nocolors,file(mylog.txt)]"
 chronicles_timestamps=None
-
 [Output]
-mylog.txt="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+mylog.txt="""INF main started                               topics="main" tid=26141 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26141 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/sinks/custom_file_notimestamps.test
+++ b/tests/sinks/custom_file_notimestamps.test
@@ -1,8 +1,7 @@
 program=lexical_scopes
 chronicles_sinks="textlines[notimestamps,file(mylog.txt)]"
 chronicles_colors=None
-
 [Output]
-mylog.txt="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+mylog.txt="""INF main started                               topics="main" tid=26319 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26319 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/sinks/double_sink.test
+++ b/tests/sinks/double_sink.test
@@ -2,28 +2,26 @@ program=lexical_scopes
 chronicles_sinks="textlines[file(lines.txt,truncate)],textblocks[file(blocks.txt,truncate)]"
 chronicles_timestamps=None
 chronicles_colors=None
-
 [Output]
-lines.txt="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+lines.txt="""INF main started                               topics="main" tid=26342 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26342 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
 blocks.txt="""INF main started topics="main"
-  tid: 0
-  a: 10
-  arg: 50
-  b: inner-b
-  c: 10
-  d: some-d
-  x: 16
-  z: 20
-
-INF exiting
-  tid: 0
+  tid: 26342
   a: 12
   b: overriden-b
-  c: 100
-  msg: bye bye
+  d: some-d
+  arg: 50
+  z: 20
   x: 16
+  c: 10
+
+INF exiting
+  tid: 26342
+  msg: bye bye
+  b: overriden-b
+  x: 16
+  c: 100
+  a: 12
 
 """

--- a/tests/sinks/json_file_stdout.test
+++ b/tests/sinks/json_file_stdout.test
@@ -2,12 +2,14 @@ program=lexical_scopes
 chronicles_sinks="json[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-stdout="""{"lvl":"INF","msg":"main started","topics":"main","tid":13250,"a":10,"arg":50,"b":"inner-b","c":10,"d":"some-d","x":16,"z":20}
-{"lvl":"INF","msg":"exiting","tid":0,"a":12,"b":"overriden-b","c":100,"msg":"bye bye","x":16}
+json_file_stdout.log="""{"lvl":"INF","msg":"main started","topics":"main","tid":21495,"a":12,"b":"overriden-b","d":"some-d","arg":50,"z":20,"x":16,"c":10}
+{"lvl":"INF","msg":"exiting","tid":21495,"msg":"bye bye","b":"overriden-b","x":16,"c":100,"a":12}
+{"lvl":"INF","msg":"main started","topics":"main","tid":22790,"a":12,"b":"overriden-b","d":"some-d","arg":50,"z":20,"x":16,"c":10}
+{"lvl":"INF","msg":"exiting","tid":22790,"msg":"bye bye","b":"overriden-b","x":16,"c":100,"a":12}
+{"lvl":"INF","msg":"main started","topics":"main","tid":26106,"a":12,"b":"overriden-b","d":"some-d","arg":50,"z":20,"x":16,"c":10}
+{"lvl":"INF","msg":"exiting","tid":26106,"msg":"bye bye","b":"overriden-b","x":16,"c":100,"a":12}
 """
-
-json_file_stdout.log="""{"lvl":"INF","msg":"main started","topics":"main","tid":13250,"a":10,"arg":50,"b":"inner-b","c":10,"d":"some-d","x":16,"z":20}
-{"lvl":"INF","msg":"exiting","tid":0,"a":12,"b":"overriden-b","c":100,"msg":"bye bye","x":16}
+stdout="""{"lvl":"INF","msg":"main started","topics":"main","tid":26106,"a":12,"b":"overriden-b","d":"some-d","arg":50,"z":20,"x":16,"c":10}
+{"lvl":"INF","msg":"exiting","tid":26106,"msg":"bye bye","b":"overriden-b","x":16,"c":100,"a":12}
 """

--- a/tests/sinks/property_per_sink.test
+++ b/tests/sinks/property_per_sink.test
@@ -1,27 +1,25 @@
 program=lexical_scopes
 chronicles_sinks="textlines[file(lines.txt,truncate),nocolors],textblocks[file(blocks.txt,truncate),notimestamps,ansicolors]"
-
 [Output]
-lines.txt="""INF 2018-10-12 12:24:21+02:00 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 2018-10-12 12:24:21+02:00 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+lines.txt="""INF 2020-02-25 17:04:35+02:00 main started                               topics="main" tid=26216 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 2020-02-25 17:04:35+02:00 exiting                                    tid=26216 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
 blocks.txt="""[32mINF[0m [1mmain started[0m topics="[93mmain[0m"
-  [34mtid: [1m0
-[0m  [34ma: [1m10
-[0m  [34marg: [1m50
-[0m  [34mb: [1minner-b
-[0m  [34mc: [1m10
-[0m  [34md: [1msome-d
-[0m  [34mx: [1m16
-[0m  [34mz: [1m20
-[0m
-[32mINF[0m [1mexiting[0m
-  [34mtid: [1m0
+  [34mtid: [1m26216
 [0m  [34ma: [1m12
 [0m  [34mb: [1moverriden-b
-[0m  [34mc: [1m100
-[0m  [34mmsg: [1mbye bye
+[0m  [34md: [1msome-d
+[0m  [34marg: [1m50
+[0m  [34mz: [1m20
 [0m  [34mx: [1m16
+[0m  [34mc: [1m10
+[0m
+[32mINF[0m [1mexiting[0m
+  [34mtid: [1m26216
+[0m  [34mmsg: [1mbye bye
+[0m  [34mb: [1moverriden-b
+[0m  [34mx: [1m16
+[0m  [34mc: [1m100
+[0m  [34ma: [1m12
 [0m
 """

--- a/tests/sinks/textblocks_file_stdout.test
+++ b/tests/sinks/textblocks_file_stdout.test
@@ -2,44 +2,78 @@ program=lexical_scopes
 chronicles_sinks="textblocks[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-stdout="""INF main started topics="main"
-  tid: 0
-  a: 10
-  arg: 50
-  b: inner-b
-  c: 10
-  d: some-d
-  x: 16
-  z: 20
-
-INF exiting
-  tid: 0
+textblocks_file_stdout.log="""INF main started topics="main"
+  tid: 21468
   a: 12
   b: overriden-b
-  c: 100
-  msg: bye bye
+  d: some-d
+  arg: 50
+  z: 20
   x: 16
+  c: 10
+
+INF exiting
+  tid: 21468
+  msg: bye bye
+  b: overriden-b
+  x: 16
+  c: 100
+  a: 12
+
+INF main started topics="main"
+  tid: 22760
+  a: 12
+  b: overriden-b
+  d: some-d
+  arg: 50
+  z: 20
+  x: 16
+  c: 10
+
+INF exiting
+  tid: 22760
+  msg: bye bye
+  b: overriden-b
+  x: 16
+  c: 100
+  a: 12
+
+INF main started topics="main"
+  tid: 26075
+  a: 12
+  b: overriden-b
+  d: some-d
+  arg: 50
+  z: 20
+  x: 16
+  c: 10
+
+INF exiting
+  tid: 26075
+  msg: bye bye
+  b: overriden-b
+  x: 16
+  c: 100
+  a: 12
 
 """
-
-textblocks_file_stdout.log="""INF main started topics="main"
-  tid: 0
-  a: 10
-  arg: 50
-  b: inner-b
-  c: 10
-  d: some-d
-  x: 16
-  z: 20
-
-INF exiting
-  tid: 0
+stdout="""INF main started topics="main"
+  tid: 26075
   a: 12
   b: overriden-b
-  c: 100
-  msg: bye bye
+  d: some-d
+  arg: 50
+  z: 20
   x: 16
+  c: 10
+
+INF exiting
+  tid: 26075
+  msg: bye bye
+  b: overriden-b
+  x: 16
+  c: 100
+  a: 12
 
 """

--- a/tests/sinks/textlines_file.test
+++ b/tests/sinks/textlines_file.test
@@ -2,8 +2,11 @@ program=lexical_scopes
 chronicles_sinks="textlines[file]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-textlines_file.log="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+textlines_file.log="""INF main started                               topics="main" tid=21647 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=21647 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF main started                               topics="main" tid=22935 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=22935 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF main started                               topics="main" tid=26261 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26261 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/sinks/textlines_file_stdout.test
+++ b/tests/sinks/textlines_file_stdout.test
@@ -2,12 +2,14 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-stdout="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+textlines_file_stdout.log="""INF main started                               topics="main" tid=21441 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=21441 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF main started                               topics="main" tid=22733 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=22733 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF main started                               topics="main" tid=26048 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26048 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
-textlines_file_stdout.log="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+stdout="""INF main started                               topics="main" tid=26048 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26048 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/sinks/textlines_stdout.test
+++ b/tests/sinks/textlines_stdout.test
@@ -2,8 +2,7 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-stdout="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+stdout="""INF main started                               topics="main" tid=26172 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26172 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/sinks/tripple_sink.test
+++ b/tests/sinks/tripple_sink.test
@@ -2,32 +2,29 @@ program=lexical_scopes
 chronicles_sinks="textlines[file(lines.txt,truncate)],textblocks[file(blocks.txt,truncate)],json[file(log.json,truncate)]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-lines.txt="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+lines.txt="""INF main started                               topics="main" tid=26292 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26292 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
+log.json="""{"lvl":"INF","msg":"main started","topics":"main","tid":26292,"a":12,"b":"overriden-b","d":"some-d","arg":50,"z":20,"x":16,"c":10}
+{"lvl":"INF","msg":"exiting","tid":26292,"msg":"bye bye","b":"overriden-b","x":16,"c":100,"a":12}
+"""
 blocks.txt="""INF main started topics="main"
-  tid: 0
-  a: 10
-  arg: 50
-  b: inner-b
-  c: 10
-  d: some-d
-  x: 16
-  z: 20
-
-INF exiting
-  tid: 0
+  tid: 26292
   a: 12
   b: overriden-b
-  c: 100
-  msg: bye bye
+  d: some-d
+  arg: 50
+  z: 20
   x: 16
+  c: 10
 
-"""
+INF exiting
+  tid: 26292
+  msg: bye bye
+  b: overriden-b
+  x: 16
+  c: 100
+  a: 12
 
-log.json="""{"lvl":"INF","msg":"main started","topics":"main","tid":0,"a":10,"arg":50,"b":"inner-b","c":10,"d":"some-d","x":16,"z":20}
-{"lvl":"INF","msg":"exiting","tid":0,"a":12,"b":"overriden-b","c":100,"msg":"bye bye","x":16}
 """

--- a/tests/streams/xml_stream_usage.test
+++ b/tests/streams/xml_stream_usage.test
@@ -1,11 +1,10 @@
 program=xml_stream_usage
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
 stdout="""<event type="New Stream" severity="INFO">
-  <tid>0</tid>
-  <episode>Smarty Cat</episode>
+  <tid>25861</tid>
   <franchise>Tom &amp; Jerry</franchise>
+  <episode>Smarty Cat</episode>
 </event>
 """

--- a/tests/timestamps/no_timestamps.test
+++ b/tests/timestamps/no_timestamps.test
@@ -2,12 +2,14 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=None
-
 [Output]
-stdout="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+no_timestamps.log="""INF main started                               topics="main" tid=22094 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=22094 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF main started                               topics="main" tid=23459 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=23459 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF main started                               topics="main" tid=26714 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26714 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
-no_timestamps.log="""INF main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+stdout="""INF main started                               topics="main" tid=26714 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF exiting                                    tid=26714 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/timestamps/ownpeg_timestamps.test
+++ b/tests/timestamps/ownpeg_timestamps.test
@@ -2,15 +2,15 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=UnixTime
-
-; any float
-timestamp_peg=r"{\d+} '.' {\d+} \s"
-
+timestamp_peg="{\\d+} '.' {\\d+} \\s"
 [Output]
-stdout="""INF 1539371702.190928 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 1539371702.191123 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+ownpeg_timestamps.log="""INF 1582640908.612774 main started                               topics="main" tid=22164 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582640908.612812 exiting                                    tid=22164 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF 1582641361.106187 main started                               topics="main" tid=23529 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582641361.106221 exiting                                    tid=23529 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF 1582643131.192854 main started                               topics="main" tid=26785 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582643131.192885 exiting                                    tid=26785 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
-ownpeg_timestamps.log="""INF 1539371702.190928 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 1539371702.191123 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+stdout="""INF 1582643131.192854 main started                               topics="main" tid=26785 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582643131.192885 exiting                                    tid=26785 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/timestamps/rfc_timestamps.test
+++ b/tests/timestamps/rfc_timestamps.test
@@ -2,12 +2,14 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=RfcTime
-
 [Output]
-stdout="""INF 2018-10-12 21:15:05+02:00 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 2018-10-12 21:15:05+02:00 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+stdout="""INF 2020-02-25 17:05:27+02:00 main started                               topics="main" tid=26747 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 2020-02-25 17:05:27+02:00 exiting                                    tid=26747 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
-rfc_timestamps.log="""INF 2018-10-12 21:15:05+02:00 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 2018-10-12 21:15:05+02:00 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+rfc_timestamps.log="""INF 2020-02-25 16:28:24+02:00 main started                               topics="main" tid=22126 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 2020-02-25 16:28:24+02:00 exiting                                    tid=22126 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF 2020-02-25 16:35:57+02:00 main started                               topics="main" tid=23491 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 2020-02-25 16:35:57+02:00 exiting                                    tid=23491 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF 2020-02-25 17:05:27+02:00 main started                               topics="main" tid=26747 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 2020-02-25 17:05:27+02:00 exiting                                    tid=26747 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/timestamps/unix_timestamps.test
+++ b/tests/timestamps/unix_timestamps.test
@@ -2,12 +2,14 @@ program=lexical_scopes
 chronicles_sinks="textlines[stdout,file]"
 chronicles_colors=None
 chronicles_timestamps=UnixTime
-
 [Output]
-stdout="""INF 1539371702.190928 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 1539371702.191123 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+unix_timestamps.log="""INF 1582640907.727179 main started                               topics="main" tid=22157 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582640907.727220 exiting                                    tid=22157 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF 1582641360.303799 main started                               topics="main" tid=23522 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582641360.303835 exiting                                    tid=23522 msg="bye bye" b=overriden-b x=16 c=100 a=12
+INF 1582643130.405415 main started                               topics="main" tid=26778 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582643130.405445 exiting                                    tid=26778 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """
-
-unix_timestamps.log="""INF 1539371702.190928 main started                               topics="main" tid=0 a=10 arg=50 b=inner-b c=10 d=some-d x=16 z=20
-INF 1539371702.191123 exiting                                    tid=0 a=12 b=overriden-b c=100 msg="bye bye" x=16
+stdout="""INF 1582643130.405415 main started                               topics="main" tid=26778 a=12 b=overriden-b d=some-d arg=50 z=20 x=16 c=10
+INF 1582643130.405445 exiting                                    tid=26778 msg="bye bye" b=overriden-b x=16 c=100 a=12
 """

--- a/tests/topics/disabled.test
+++ b/tests/topics/disabled.test
@@ -3,12 +3,11 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
-chronicles_disabled_topics:"foo bar"
-
+chronicles_disabled_topics="foo bar"
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF after main                                 topics="general" tid=0
-INF exiting                                    tid=0 msg="bye bye"
+stdout="""WRN inside main                                topics="main" tid=26496 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26496 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26496 b=10 arg=50 a=1
+INF after main                                 topics="general" tid=26496
+INF exiting                                    tid=26496 msg="bye bye"
 """

--- a/tests/topics/enabled.test
+++ b/tests/topics/enabled.test
@@ -3,16 +3,15 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
-chronicles_enabled_topics:"main foo"
-
+chronicles_enabled_topics="main foo"
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
-WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-DBG inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-DBG inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside main                                topics="main" tid=26438 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26438 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26438 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=26438 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26438 b=10 arg=10
+DBG inside foo                                 topics="foo" tid=26438 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26438 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26438 b=10 arg=20
+DBG inside foobar                              topics="foo bar" tid=26438 b=10 arg=20
 """

--- a/tests/topics/enabled_vs_disabled.test
+++ b/tests/topics/enabled_vs_disabled.test
@@ -3,11 +3,10 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
-chronicles_enabled_topics:"main foo"
-chronicles_disabled_topics:"foo"
-
+chronicles_enabled_topics="main foo"
+chronicles_disabled_topics=foo
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
+stdout="""WRN inside main                                topics="main" tid=26477 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26477 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26477 b=10 arg=50 a=1
 """

--- a/tests/topics/required1.test
+++ b/tests/topics/required1.test
@@ -3,13 +3,12 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
-chronicles_required_topics:"foo"
-
+chronicles_required_topics=foo
 [Output]
-stdout="""WRN inside foo                                 topics="foo" tid=0 arg=10 b=10
-INF inside foo                                 topics="foo" tid=0 arg=10 b=10
-DBG inside foo                                 topics="foo" tid=0 arg=10 b=10
-WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-DBG inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside foo                                 topics="foo" tid=26518 b=10 arg=10
+INF inside foo                                 topics="foo" tid=26518 b=10 arg=10
+DBG inside foo                                 topics="foo" tid=26518 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=26518 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26518 b=10 arg=20
+DBG inside foobar                              topics="foo bar" tid=26518 b=10 arg=20
 """

--- a/tests/topics/required2.test
+++ b/tests/topics/required2.test
@@ -3,10 +3,9 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
-chronicles_required_topics:"foo bar"
-
+chronicles_required_topics="foo bar"
 [Output]
-stdout="""WRN inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-INF inside foobar                              topics="foo bar" tid=0 arg=20 b=10
-DBG inside foobar                              topics="foo bar" tid=0 arg=20 b=10
+stdout="""WRN inside foobar                              topics="foo bar" tid=26453 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=26453 b=10 arg=20
+DBG inside foobar                              topics="foo bar" tid=26453 b=10 arg=20
 """

--- a/tests/topics/required_vs_disabled2.test
+++ b/tests/topics/required_vs_disabled2.test
@@ -3,11 +3,10 @@ chronicles_sinks="textlines[stdout]"
 chronicles_colors=None
 chronicles_timestamps=None
 chronicles_log_level=DEBUG
-chronicles_required_topics:"main"
-chronicles_disabled_topics:"foo bar"
-
+chronicles_required_topics=main
+chronicles_disabled_topics="foo bar"
 [Output]
-stdout="""WRN inside main                                topics="main" tid=0 a=1 arg=50 b=10
-INF inside main                                topics="main" tid=0 a=1 arg=50 b=10
-DBG inside main                                topics="main" tid=0 a=1 arg=50 b=10
+stdout="""WRN inside main                                topics="main" tid=26470 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=26470 b=10 arg=50 a=1
+DBG inside main                                topics="main" tid=26470 b=10 arg=50 a=1
 """


### PR DESCRIPTION
The test outputs were regenerated using `testrunner --update`.
Unfortunately, some of the tests are still failing after the update (different tests seems to be affected by different issues).