### PR TITLE
Wrap logging in .noSideEffect. to support func

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,13 @@ defaultChroniclesStream.output.writer =
     database.writeLogEntry(msg)
 ```
 
+## Using Chronicles with `{.noSideEffect.}`
+
+Usage of Chronicles from `noSideEffect` procs (or `func`) is limited to the
+`trace` statement. Normal logging can be considered a side effect, but `trace`
+is meant as a debugging aid. It's analogous to Nim's `debugEcho`, which also
+bypasses the effect system.
+
 ## Teaching Chronicles about your types
 
 Chronicles can output log records in any of the formats supported by the Nim

--- a/tests/loglevel/trace_level.test
+++ b/tests/loglevel/trace_level.test
@@ -1,0 +1,9 @@
+program=no_side_effect
+chronicles_sinks="textlines[stdout]"
+chronicles_colors=None
+chronicles_timestamps=None
+chronicles_log_level=TRACE
+
+[Output]
+stdout="""TRC effect-free                                tid=0
+"""

--- a/tests/no_side_effect.nim
+++ b/tests/no_side_effect.nim
@@ -1,0 +1,6 @@
+import chronicles
+
+func main =
+  trace "effect-free"
+
+main()


### PR DESCRIPTION
This is probably a bit too crude but it allows using debug/etc from `func`.
Fixes #73