### PR TITLE
Move traceAsyncErrors to Chronicles

### DIFF
--- a/chronicles/chronos_tools.nim
+++ b/chronicles/chronos_tools.nim
@@ -1,0 +1,22 @@
+import
+  chronos,
+  ../chronicles
+
+proc catchOrQuit*(error: Exception) =
+  if error of CatchableError:
+    trace "Async operation ended with a recoverable error", err = error.msg
+  else:
+    fatal "Fatal exception reached", err = error.msg, stackTrace = getStackTrace()
+    quit 1
+
+proc traceAsyncErrors*(fut: FutureBase) =
+  fut.addCallback do (arg: pointer):
+    if not fut.error.isNil:
+      catchOrQuit fut.error[]
+
+template traceAwaitErrors*(fut: FutureBase) =
+  let f = fut
+  yield f
+  if not f.error.isNil:
+    catchOrQuit f.error[]
+


### PR DESCRIPTION
This would make it easier to use the construct in more projects