### PR TITLE
v0.12.0 Misc enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,11 @@ support options for specifying the use of colors and timestamps (for more
 info see `chronicles_colors` and `chronicles_timestamps`).
 
 The possible log destinations are `stdout`, `stderr`, `file`, `syslog`
-and `dynamic`.
+and `callback`.
 
 Please note that Chronicles also allows you to implement custom logging
-formats through the use of the `customLogStream` facility.
+formats as a simple user-supplied Nim modules. See the "custom formats"
+section for more detials.
 
 ### chronicles_default_output_device
 
@@ -285,7 +286,7 @@ transactions.info "transaction created", buyer = alice, seller = bob
 
 The streams created through `chronicles_streams` will be exported by the
 `chronicles` module itself, but you can also introduce additional streams
-in your own modules by using the helpers `logStream` and `customLogStream`.
+in your own modules by using the `logStream` helper.
 
 ### chronicles_enabled_topics
 
@@ -326,9 +327,11 @@ the program.
 Topics in `chronicles_disabled_topics` have precedence over the ones in
 `chronicles_enabled_topics` or `chronicles_required_topics`.
 
-### chronicles_disable_thread_id  
+### chronicles_thread_ids
 
-Disable log thread(tid)  
+By default, in projects compiled with the `--treads:on` option, Chronicles will
+log the current thread id in the `tid` property of each log statement. This option
+can be used to explicitly enable or disable the injection of the `tid` property.
 
 ### chronicles_log_level
 
@@ -383,6 +386,13 @@ Possible values are:
   RFC 3339: Date and Time on the Internet: Timestamps
 
   https://tools.ietf.org/html/rfc3339
+
+  The timestamps produced by Chronicles will be in the UTC timezone.
+
+- `LocalRfcTime`
+
+  Same as above, but the timestamps will show the local time plus
+  local offsets as specified in the RFC.
 
 - `UnixTime`
 
@@ -502,9 +512,9 @@ the default automatically:
    chronicles will add an index such as `.2.log`, `.3.log` .. `.N.log`
    to the final file name.
 
-## Working with `dynamic` outputs
+## Working with `callback` outputs
 
-A `dynamic` output redirects all logged messages to a closure supplied by
+A `callback` output redirects all logged messages to a closure supplied by
 the host application. Similar to working with file ouputs [file outputs](#working-with-file-outputs),
 you can use the `output` and `outputs` properties of a Chronicles stream
 to specify a gcsafe closure:

--- a/chronicles.nimble
+++ b/chronicles.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "chronicles"
-version       = "0.10.1"
+version       = "0.12.0"
 author        = "Status Research & Development GmbH"
 description   = "A crafty implementation of structured logging for Nim"
 license       = "Apache License 2.0"
@@ -9,6 +9,8 @@ skipDirs      = @["tests"]
 
 requires "nim >= 1.2.0"
 requires "testutils"
+requires "faststreams"
+requires "serialization"
 requires "json_serialization"
 
 task test, "run CPU tests":

--- a/chronicles/dynamic_scope_types.nim
+++ b/chronicles/dynamic_scope_types.nim
@@ -1,13 +1,21 @@
+import
+  typetraits
+
 when defined(js):
   type UncheckedArray[T] = seq[T]
 
-type
-  ScopeBindingBase*[LogRecord] = object of RootObj
-    name*: string
-    appender*: LogAppender[LogRecord]
+func arityFixed(T: typedesc): int {.compileTime.} =
+  # TODO: File this as a Nim bug
+  type TT = T
+  arity(TT)
 
+type
   LogAppender*[LogRecord] = proc(x: var LogRecord,
                                  valueAddr: ptr ScopeBindingBase[LogRecord])
+
+  ScopeBindingBase*[LogRecord] = object of RootObj
+    name*: string
+    appenders*: array[arityFixed(LogRecord), LogAppender[LogRecord]]
 
   ScopeBinding*[LogRecord, T] = object of ScopeBindingBase[LogRecord]
     value*: T

--- a/chronicles/helpers.nim
+++ b/chronicles/helpers.nim
@@ -2,8 +2,8 @@ import
   tables, strutils, strformat,
   topics_registry
 
-func parseTopicDirectives*(directives: openarray[string]): Table[string, TopicSettings] =
-  result = initTable[string, TopicSettings]()
+func parseTopicDirectives*(directives: openarray[string]): Table[string, SinkTopicSettings] =
+  result = initTable[string, SinkTopicSettings]()
 
   for directive in directives:
     let subDirectives = directive.split(";")
@@ -18,13 +18,13 @@ func parseTopicDirectives*(directives: openarray[string]): Table[string, TopicSe
         for name2 in topicsNames:
           let name = name2.strip
           if not result.hasKey(name):
-            result.add(name, TopicSettings())
+            result.add(name, default(SinkTopicSettings))
           template topic: auto = result[name]
           body
 
       case toLowerAscii(parts[0].strip)
       of "required":
-        forEachTopic: topic().state = Required
+        forEachTopic: topic.state = Required
       of "disabled":
         forEachTopic: topic.state = Disabled
       of "trc", "trace":

--- a/chronicles/json_records.nim
+++ b/chronicles/json_records.nim
@@ -1,0 +1,81 @@
+import
+  options, log_output
+
+when not defined(js):
+  import
+    faststreams/outputs,
+    json_serialization
+
+  export
+    outputs, json_serialization
+
+  type
+    LogRecord*[OutputKind;
+               timestamps: static[TimestampScheme],
+               colors: static[ColorScheme]] = object
+      output*: OutputStream
+      jsonWriter: Json.Writer
+
+  template setProperty*(r: var LogRecord, key: string, val: auto) =
+    writeField(r.jsonWriter, key, val)
+
+  template flushRecord*(r: var LogRecord) =
+    r.jsonWriter.endRecord()
+    r.output.write '\n'
+    flushOutput r.OutputKind, r.output
+
+else:
+  import
+    jscore, jsconsole, jsffi
+
+  export
+    convertToConsoleLoggable
+
+  type
+    JsonString* = distinct string
+
+  type
+    LogRecord*[OutputKind;
+               timestamps: static[TimestampScheme],
+               colors: static[ColorScheme]] = object
+      output*: Output
+      record: js
+
+  template setProperty*(r: var LogRecord, key: string, val: auto) =
+    r.record[key] = when val is string: cstring(val) else: val
+
+  proc flushRecord*(r: var LogRecord) =
+    r.output.append JSON.stringify(r.record)
+    flushOutput r.OutputKind, r.output
+
+import typetraits
+
+proc initLogRecord*(r: var LogRecord,
+                    level: LogLevel,
+                    topics: string,
+                    msg: string) =
+  r.output = initOutputStream type(r)
+
+  when defined(js):
+    r.record = newJsObject()
+  else:
+    r.jsonWriter = Json.Writer.init(r.output, pretty = false)
+    r.jsonWriter.beginRecord()
+
+  if level != NONE:
+    setProperty(r, "lvl", level.shortName)
+
+  when r.timestamps != NoTimestamps:
+    when not defined(js):
+      r.jsonWriter.writeFieldName("ts")
+      when r.timestamps in {RfcTime, LocalRfcTime}: r.output.write '"'
+      r.writeTs()
+      when r.timestamps in {RfcTime, LocalRfcTime}: r.output.write '"'
+      r.jsonWriter.fieldWritten()
+    else:
+      setProperty(r, "ts", r.timestamp())
+
+  setProperty(r, "msg", msg)
+
+  if topics.len > 0:
+    setProperty(r, "topics", topics)

--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -1,29 +1,15 @@
 import
-  strutils, times, macros, options, os,
+  strutils, times, macros, options, os, terminal,
+  stew/objects, stew/shims/strings,
+  faststreams/[textio, stdout], serialization,
   dynamic_scope_types
 
 when defined(js):
-  import
-    jscore, jsconsole, jsffi
-
-  export
-    convertToConsoleLoggable
-
   type OutStr = cstring
 
 else:
-  import
-    terminal,
-    faststreams/outputs, json_serialization/writer
-
-  export
-    outputs, writer
-
-  type OutStr = string
-
-  const
-    propColor = fgBlue
-    topicsColor = fgYellow
+  type
+    OutStr = openarray[char]
 
 export
   LogLevel
@@ -42,30 +28,15 @@ type
 
   LogOutputStr* = OutStr
 
-  DynamicOutput* = object
+  CallbackOutput* = object
     currentRecordLevel: LogLevel
     writer*: proc (logLevel: LogLevel, logRecord: OutStr) {.gcsafe, raises: [Defect].}
 
   PassThroughOutput*[FinalOutputs: tuple] = object
     finalOutputs: FinalOutputs
 
-  BufferedOutput*[FinalOutputs: tuple] = object
-    finalOutputs: FinalOutputs
-    buffer: string
-
   AnyFileOutput = FileOutput|StdOutOutput|StdErrOutput
-  AnyOutput = AnyFileOutput|SysLogOutput|BufferedOutput|PassThroughOutput
-
-  TextLineRecord*[Output;
-                  timestamps: static[TimestampsScheme],
-                  colors: static[ColorScheme]] = object
-    output*: Output
-    level: LogLevel
-
-  TextBlockRecord*[Output;
-                   timestamps: static[TimestampsScheme],
-                   colors: static[ColorScheme]] = object
-    output*: Output
+  AnyOutput = AnyFileOutput|SysLogOutput|PassThroughOutput
 
   StreamOutputRef*[Stream; outputId: static[int]] = object
 
@@ -74,23 +45,6 @@ type
     recordType: NimNode
     outputsTuple: NimNode
 
-when defined(js):
-  type
-    JsonRecord*[Output; timestamps: static[TimestampsScheme]] = object
-      output*: Output
-      record: js
-
-    JsonString* = distinct string
-else:
-  type
-    JsonRecord*[Output; timestamps: static[TimestampsScheme]] = object
-      output*: Output
-      outStream: OutputStream
-      jsonWriter: Json.Writer
-
-export
-  JsonString
-
 when defined(posix):
   {.pragma: syslog_h, importc, header: "<syslog.h>"}
 
@@ -98,8 +52,9 @@ when defined(posix):
   proc syslog(priority: int, format: cstring, msg: cstring) {.syslog_h.}
   # proc closelog() {.syslog_h.}
 
-  var LOG_EMERG {.syslog_h.}: int
-  var LOG_ALERT {.syslog_h.}: int
+  # Unused syslog levels:
+  # var LOG_EMERG {.syslog_h.}: int
+  # var LOG_ALERT {.syslog_h.}: int
   var LOG_CRIT {.syslog_h.}: int
   var LOG_ERR {.syslog_h.}: int
   var LOG_WARNING {.syslog_h.}: int
@@ -158,14 +113,27 @@ template ignoreIOErrors(body: untyped) =
   try: body
   except IOError: discard
 
-proc logLoggingFailure*(msg: cstring, ex: ref Exception) =
+proc logLoggingFailure*(msg: LogOutputStr, ex: ref Exception) =
   ignoreIOErrors:
     stderr.writeLine("[Chronicles] Log message not delivered: ", msg)
     if ex != nil: stderr.writeLine(ex.msg)
 
-template undeliveredMsg(reason: string, logMsg: OutStr, ex: ref Exception) =
-  const error = "[Chronicles] " & reason & ". Log message not delivered: "
-  logLoggingFailure(cstring(error & logMsg), ex)
+proc undeliveredMsg(reason: string, logMsg: OutStr, ex: ref Exception) =
+  const
+    lineTag = "[Chronicles] "
+    infoMsg = ". Log message not delivered: "
+
+  var msg = newStringOfCap(lineTag.len + reason.len + infoMsg.len + logMsg.len)
+  msg.add lineTag
+  msg.add reason
+  msg.add infoMsg
+  msg.add logMsg
+
+  logLoggingFailure(msg, ex)
+
+proc undeliveredMsg(reason: string, logMsg: openArray[byte], ex: ref Exception) =
+  var charArray = cast[ptr UncheckedArray[char]](unsafeAddr logMsg[0])
+  undeliveredMsg(reason, toOpenArray(charArray, 0, logMsg.len - 1), ex)
 
 # XXX:
 # Uncomenting this leads to an error message that the Outputs tuple
@@ -220,17 +188,20 @@ proc selectOutputType(s: var StreamCodeNodes, dst: LogDestination): NimNode =
                                    newLit($s.streamName), newLit(outputId))
 
       s.outputsTuple.add newCall(bindSym"createFileOutput", fileName, mode)
-  elif dst.kind == oDynamic:
+  elif dst.kind == oCallback:
     outputId = s.outputsTuple.len
-    s.outputsTuple.add newTree(nnkObjConstr, bnd"DynamicOutput")
+    s.outputsTuple.add newTree(nnkObjConstr, bnd"CallbackOutput")
 
   case dst.kind
   of oStdOut: bnd"StdOutOutput"
   of oStdErr: bnd"StdErrOutput"
   of oSysLog: bnd"SysLogOutput"
-  of oFile, oDynamic:
+  of oFile, oCallback:
     newTree(nnkBracketExpr,
             bnd"StreamOutputRef", s.streamName, newLit(outputId))
+
+template id(fmt: LogFormatPlugin): string =
+  "chronicles_" & toHex(string fmt)
 
 proc selectRecordType(s: var StreamCodeNodes, sink: SinkSpec): NimNode =
   # This proc translates the SinkSpecs loaded in the `options` module
@@ -250,32 +221,23 @@ proc selectRecordType(s: var StreamCodeNodes, sink: SinkSpec): NimNode =
   #
   # The faststreams-based outputs (such as json) are already buffered,
   # so we don't need to handle them in a special way.
-  #
 
-  # Determine the head symbol of the instantiation
-  let RecordType = case sink.format
-                   of json: bnd"JsonRecord"
-                   of textLines: bnd"TextLineRecord"
-                   of textBlocks: bnd"TextBlockRecord"
-
-  result = newTree(nnkBracketExpr, RecordType)
+  result = newTree(nnkBracketExpr,
+                   newTree(nnkDotExpr, ident(sink.format.id), ident("LogRecord")))
 
   # Check if a buffered output is needed
-  if defined(js) or
-     sink.destinations.len > 1 or
-     sink.destinations[0].kind in {oSyslog,oDynamic} or
-     compileOption("threads"):
+  if false:
+     #defined(js) or
+     #sink.destinations.len > 1 or
+     #sink.destinations[0].kind in {oSyslog,oCallback} or
+     #compileOption("threads"):
 
     # Here, we build the list of outputs as a tuple
     var outputsTuple = newTree(nnkTupleConstr)
     for dst in sink.destinations:
       outputsTuple.add selectOutputType(s, dst)
 
-    var outputType = if sink.format in {textLines, textBlocks}:
-      bnd"BufferedOutput"
-    else:
-      bnd"PassThroughOutput"
-
+    var outputType = bnd"PassThroughOutput"
     result.add newTree(nnkBracketExpr, outputType, outputsTuple)
   else:
     result.add selectOutputType(s, sink.destinations[0])
@@ -283,19 +245,20 @@ proc selectRecordType(s: var StreamCodeNodes, sink: SinkSpec): NimNode =
   result.add newIdentNode($sink.timestamps)
 
   # Set the color scheme for the record types that require it
-  if sink.format != json:
-    var colorScheme = sink.colorScheme
-    when not defined(windows):
-      # `NativeColors' means `AnsiColors` on non-Windows platforms:
-      if colorScheme == NativeColors: colorScheme = AnsiColors
-    result.add newIdentNode($colorScheme)
+  var colorScheme = sink.colorScheme
+  when not defined(windows):
+    # `NativeColors' means `AnsiColors` on non-Windows platforms:
+    if colorScheme == NativeColors:
+      colorScheme = AnsiColors
+  result.add newIdentNode($colorScheme)
 
 # The `append` and `flushOutput` functions implement the actual writing
 # to the log destinations (which we call Outputs).
 # The LogRecord types are parametric on their Output and this is how we
 # can support arbitrary combinations of log formats and destinations.
 
-template activateOutput*(o: var (StdOutOutput|StdErrOutput), level: LogLevel) =
+template activateOutput*(o: var (StdOutOutput|StdErrOutput|OutputStream),
+                         level: LogLevel) =
   discard
 
 template activateOutput*(o: var FileOutput, level: LogLevel) =
@@ -304,16 +267,15 @@ template activateOutput*(o: var FileOutput, level: LogLevel) =
 template activateOutput*(o: var StreamOutputRef, level: LogLevel) =
   activateOutput(deref(o), level)
 
-template activateOutput*(o: var (SysLogOutput|DynamicOutput), level: LogLevel) =
+template activateOutput*(o: var (SysLogOutput|CallbackOutput), level: LogLevel) =
   o.currentRecordLevel = level
 
-template activateOutput*(o: var BufferedOutput|PassThroughOutput, level: LogLevel) =
+template activateOutput*(o: var PassThroughOutput, level: LogLevel) =
   for f in o.finalOutputs.fields:
     activateOutput(f, level)
 
 template prepareOutput*(r: var auto, level: LogLevel) =
   mixin activateOutput
-  r = default(type(r)) # Remove once nim is updated past #9790
 
   when r is tuple:
     for f in r.fields:
@@ -321,14 +283,27 @@ template prepareOutput*(r: var auto, level: LogLevel) =
   else:
     activateOutput(r.output, level)
 
+proc initOutputStream*(LogRecord: type): auto =
+  when true or LogRecord.OutputKind is StdOutOutput:
+    var outStream {.threadvar.}: OutputStreamHandle
+    if outStream.s == nil:
+      outStream = memoryOutput()
+    outStream.s
+  else:
+    default(LogRecord.OutputKind)
+
+proc writeOutStr(f: File, s: OutStr) =
+  # TODO: error handling
+  discard f.writeBuffer(unsafeAddr s, s.len)
+
 template append*(o: var FileOutput, s: OutStr) =
-  o.outFile.write s
+  writeOutStr(o.outFile, s)
 
 template flushOutput*(o: var FileOutput) =
   # XXX: Uncommenting this triggers a strange compile-time error
   #      when multiple sinks are used.
   # doAssert o.outFile != nil
-  o.outFile.flushFile
+  flushFile o.outFile
 
 template getOutputStream(o: FileOutput): File =
   o.outFile
@@ -342,7 +317,7 @@ when defined(js):
 
 else:
   template append*(o: var StdOutOutput, s: OutStr) =
-    try: stdout.write s
+    try: writeOutStr(stdout, s)
     except IOError as err:
       undeliveredMsg("Failed to write to stdout", s, err)
 
@@ -350,7 +325,7 @@ else:
     ignoreIOErrors(stdout.flushFile)
 
   template append*(o: var StdErrOutput, s: OutStr) =
-    ignoreIOErrors(stderr.write s)
+    ignoreIOErrors(stderr.writeOutStr s)
 
   template flushOutput*(o: var StdErrOutput) =
     ignoreIOErrors(stderr.flushFile)
@@ -361,48 +336,68 @@ template getOutputStream(o: StdErrOutput): File = stderr
 template append*(o: var StreamOutputRef, s: OutStr) = append(deref(o), s)
 template flushOutput*(o: var StreamOutputRef)       = flushOutput(deref(o))
 
+import
+  faststreams/buffers
+
+proc flushOutput*(OutputKind: type, outStream: OutputStream) =
+  let outFile = when OutputKind is StdOutOutput:
+    system.stdout
+  else:
+    system.stderr
+
+  const outputNickName = when OutputKind is StdOutOutput:
+    "stdout"
+  else:
+    "stderr"
+
+  outStream.consumeOutputs output:
+    when OutputKind is StdOutOutput|StdErrOutput:
+      try:
+        discard writeBuffer(outFile, unsafeAddr output[0], len output)
+      except IOError as err:
+        undeliveredMsg("Failed to write to " & outputNickName, output, err)
+
+    else:
+      # TODO
+      echo "Flushing"
+
+template append*(o: OutputStream, s: string) =
+  write(o, s)
+
+template append*(o: OutputStream, s: openarray[char]) =
+  write(o, s)
+
 template getOutputStream(o: StreamOutputRef): File =
   getOutputStream(deref(o))
 
+proc toCstring(s: OutStr): cstring =
+  static: assert s is openarray[char]
+  cast[cstring](s)
+
 template append*(o: var SysLogOutput, s: OutStr) =
   let syslogLevel = case o.currentRecordLevel
-                    of TRACE, DEBUG, NONE: LOG_DEBUG
+                    of TRACE, DEBUG:       LOG_DEBUG
                     of INFO:               LOG_INFO
                     of NOTICE:             LOG_NOTICE
                     of WARN:               LOG_WARNING
                     of ERROR:              LOG_ERR
                     of FATAL:              LOG_CRIT
+                    of DEFAULT, NONE:      LOG_DEBUG # The code will not reach here
 
-  syslog(syslogLevel or LOG_PID, "%s", s)
+  syslog(syslogLevel or LOG_PID, "%s", s.toCstring)
 
-template append*(o: var DynamicOutput, s: OutStr) =
+template append*(o: var CallbackOutput, s: OutStr) =
   if o.writer.isNil:
-    undeliveredMsg "A writer was not configured for a dynamic log output device", s, nil
+    undeliveredMsg "A writer was not configured for a callback output", s, nil
   else:
     (o.writer)(o.currentRecordLevel, s)
 
-template flushOutput*(o: var (SysLogOutput|DynamicOutput)) = discard
-
-# The buffered Output works in a very simple way. The log message is first
-# buffered into a sting and when it needs to be flushed, we just instantiate
-# each of the Output types and call `append` and `flush` on the instance:
-
-template append*(o: var BufferedOutput, s: OutStr) =
-  o.buffer.add(s)
-
-template flushOutput*(o: var BufferedOutput) =
-  for f in o.finalOutputs.fields:
-    append(f, o.buffer)
-    flushOutput(f)
-
-template getOutputStream(o: BufferedOutput|PassThroughOutput): File =
-  getOutputStream(o.finalOutputs[0])
+template flushOutput*(o: var (SysLogOutput|CallbackOutput)) = discard
 
 # The pass-through output just acts as a proxy, redirecting a single `append`
 # call to multiple destinations:
 
-template append*(o: var PassThroughOutput, strExpr: OutStr) =
-  let str = strExpr
+proc append*(o: var PassThroughOutput, str: OutStr) =
   for f in o.finalOutputs.fields:
     append(f, str)
 
@@ -422,40 +417,91 @@ macro append*(o: var AnyOutput,
   result.add newCall("append", o, arg2)
   for arg in restArgs: result.add newCall("append", o, arg)
 
-proc rfcTimestamp: string =
-  now().format("yyyy-MM-dd HH:mm:ss'.'fffzzz")
+var timezone: array[6, char]
+var timezoneUpdatedAt = -1
 
-proc epochTimestamp: string =
+const rfcFormat = initTimeFormat "yyyy-MM-dd HH:mm:ss'.'fff"
+template rfcTimestamp: string =
+  now().format(rfcFormat)
+
+const localRfcFormat = initTimeFormat "yyyy-MM-dd HH:mm:ss'.'fffzzz"
+template localRfcTimestamp: string =
+  now().format(localRfcFormat)
+
+template epochTimestamp: string =
   formatFloat(epochTime(), ffDecimal, 6)
 
-template timestamp(record): string =
-  when record.timestamps == RfcTime:
+template writeTs*(record) =
+  when record.timestamps in {RfcTime, LocalRfcTime}:
+    let t = utc getTime()
+    writeText record.output, t.year
+    write record.output, '-'
+    writeText record.output, t.month.ord
+    write record.output, '-'
+    writeText record.output, t.monthday
+    write record.output, ' '
+    writeText record.output, t.hour
+    write record.output, ':'
+    writeText record.output, t.minute
+    write record.output, ':'
+    writeText record.output, t.second
+    write record.output, '.'
+    writeText record.output, t.nanosecond div 1000000
+    when record.timestamps == RfcTime:
+      write record.output, 'Z'
+    else:
+      if timezoneUpdatedAt != t.minute:
+        # TODO: This can be done more efficiently by
+        # using a specialized function returning the
+        # current timezone offset.
+        timezone = toArray(6, now().format("zzz"))
+      write record.output, timezone
+  else:
+    when record.output is OutputStream:
+      record.output.writeText epochTime()
+    else:
+      append record.output, epochTimestamp()
+
+template writeSpaceAndTs*(record) =
+  when record.timestamps != NoTimestamps:
+    append record.output, " "
+    writeTs(record)
+
+template timestamp*(record): string =
+  when record.timestamp == RfcTime:
     rfcTimestamp()
+  elif record.timestamp == LocalRfcTime:
+    localRfcTimestamp()
   else:
     epochTimestamp()
 
-template writeTs(record) =
-  append(record.output, timestamp(record))
+#
+# color and style support functions
+#
 
-template fgColor(record, color, brightness) =
+const
+  propColor* = fgBlue
+  topicsColor* = fgYellow
+
+template setFgColor*(record, color, brightness) =
   when record.colors == AnsiColors:
     append(record.output, ansiForegroundColorCode(color, brightness))
   elif record.colors == NativeColors:
     setForegroundColor(getOutputStream(record.output), color, brightness)
 
-template resetColors(record) =
+template resetColors*(record) =
   when record.colors == AnsiColors:
     append(record.output, ansiResetCode)
   elif record.colors == NativeColors:
     resetAttributes(getOutputStream(record.output))
 
-template applyStyle(record, style) =
+template applyStyle*(record, style) =
   when record.colors == AnsiColors:
     append(record.output, ansiStyleCode(style))
   elif record.colors == NativeColors:
     setStyle(getOutputStream(record.output), {style})
 
-template levelToStyle(lvl: LogLevel): untyped =
+template levelToStyle*(lvl: LogLevel): untyped =
   # Bright Black is gray
   # Light green doesn't display well on white consoles
   # Light yellow doesn't display well on white consoles
@@ -464,230 +510,42 @@ template levelToStyle(lvl: LogLevel): untyped =
   case lvl
   of TRACE: (fgWhite, false)
   of DEBUG: (fgBlack, true) # Bright Black is gray
-  of INFO:  (fgCyan, true)
+  of INFO:  (fgGreen, true)
   of NOTICE:(fgMagenta, false)
   of WARN:  (fgYellow, false)
   of ERROR: (fgRed, true)
   of FATAL: (fgRed, false)
-  of NONE:  (fgWhite, false)
+  of DEFAULT, NONE: (fgWhite, false)
 
-template shortName(lvl: LogLevel): string =
+template shortName*(lvl: LogLevel): string =
   # Same-length strings make for nice alignment
   case lvl
-  of TRACE: "TRC"
-  of DEBUG: "DBG"
-  of INFO:  "INF"
-  of NOTICE:"NOT"
-  of WARN:  "WRN"
-  of ERROR: "ERR"
-  of FATAL: "FAT"
-  of NONE:  "   "
+  of TRACE:   "TRC"
+  of DEBUG:   "DBG"
+  of INFO:    "INF"
+  of NOTICE:  "NOT"
+  of WARN:    "WRN"
+  of ERROR:   "ERR"
+  of FATAL:   "FAT"
+  of DEFAULT, NONE: "   "
 
-template appendLogLevelMarker(r: var auto, lvl: LogLevel, align: bool) =
-  when r.colors != NoColors:
+proc `$`*(ex: ref Exception): string =
+  result = ""
+  result &= "exception " & $ex.name & "\n"
+  result &= "msg \"" & $ex.msg & "\"\n"
+  when not defined(js) and not defined(nimscript) and hostOS != "standalone":
+    result &= "location " & getStackTrace(ex).strip
+
+# TODO
+template writeLogLevel*(s: OutputStream,
+                        colorScheme: static ColorScheme,
+                        lvl: LogLevel) =
+  when colorScheme != NoColors:
     let (color, bright) = levelToStyle(lvl)
-    fgColor(r, color, bright)
+    setFgColor(s, colorScheme, color, bright)
 
-  append(r.output, when align: shortName(lvl)
-                   else: $lvl)
-  resetColors(r)
-
-template appendHeader(r: var TextLineRecord | var TextBlockRecord,
-                      lvl: LogLevel,
-                      topics: string,
-                      name: string,
-                      pad: bool) =
-  # Log level comes first - allows for easy regex match with ^
-  appendLogLevelMarker(r, lvl, true)
-
-  when r.timestamps != NoTimestamps:
-    append(r.output, " ")
-    writeTs(r)
-
-  if name.len > 0:
-    # no good way to tell how much padding is going to be needed so we
-    # choose an arbitrary number and use that - should be fine even for
-    # 80-char terminals
-    # XXX: This should be const, but the compiler fails with an ICE
-    let padding = repeat(' ', if pad: 42 - min(42, name.len) else: 0)
-
-    append(r.output, " ")
-    applyStyle(r, styleBright)
-    append(r.output, name)
-    append(r.output, padding)
-    resetColors(r)
-
-  if topics.len > 0:
-    append(r.output, " topics=\"")
-    fgColor(r, topicsColor, true)
-    append(r.output, topics)
-    resetColors(r)
-    append(r.output, "\"")
-
-#
-# A LogRecord is a single "logical line" in the output.
-#
-# 1. It's instantiated by the log statement.
-#
-# 2. It's initialized with a call to `initLogRecord`.
-#
-# 3. Zero or more calls to `setFirstProperty` and `setPropery` are
-#    executed with the current lixical and dynamic bindings.
-#
-# 4. Finally, `flushRecord` should wrap-up the record and flush the output.
-#
-
-#
-# Text line records:
-#
-
-proc initLogRecord*(r: var TextLineRecord,
-                    lvl: LogLevel,
-                    topics: string,
-                    name: string) =
-  r.level = lvl
-  appendHeader(r, lvl, topics, name, true)
-
-proc setProperty*(r: var TextLineRecord, key: string, val: auto) =
-  append(r.output, " ")
-  let valText = $val
-
-  var
-    escaped: string
-    valueToWrite: ptr string
-
-  # Escaping is done to avoid issues with quoting and newlines
-  # Quoting is done to distinguish strings with spaces in them from a new
-  # key-value pair
-  # This is similar to how it's done in logfmt:
-  # https://github.com/csquared/node-logfmt/blob/master/lib/stringify.js#L13
-  let
-    needsEscape = valText.find(NewLines + {'"', '\\'}) > -1
-    needsQuote = valText.find({' ', '='}) > -1
-
-  if needsEscape or needsQuote:
-    escaped = newStringOfCap(valText.len + valText.len div 8)
-    if needsEscape:
-      # addQuoted adds quotes and escapes a bunch of characters
-      # XXX addQuoted escapes more characters than what we look for in above
-      #     needsEscape check - it's a bit weird that way
-      addQuoted(escaped, valText)
-    elif needsQuote:
-      add(escaped, '"')
-      add(escaped, valText)
-      add(escaped, '"')
-    valueToWrite = addr escaped
-  else:
-    valueToWrite = unsafeAddr valText
-
-  when r.colors != NoColors:
-    let (color, bright) = levelToStyle(r.level)
-    fgColor(r, color, bright)
-  append(r.output, key)
-  resetColors(r)
-  append(r.output, "=")
-  fgColor(r, propColor, true)
-  append(r.output, valueToWrite[])
-  resetColors(r)
-
-template setFirstProperty*(r: var TextLineRecord, key: string, val: auto) =
-  setProperty(r, key, val)
-
-proc flushRecord*(r: var TextLineRecord) =
-  append(r.output, "\n")
-  flushOutput(r.output)
-
-#
-# Textblock records:
-#
-
-proc initLogRecord*(r: var TextBlockRecord,
-                    level: LogLevel,
-                    topics: string,
-                    name: string) =
-  appendHeader(r, level, topics, name, false)
-  append(r.output, "\n")
-
-proc setProperty*(r: var TextBlockRecord, key: string, val: auto) =
-  let valText = $val
-
-  append(r.output, textBlockIndent)
-  fgColor(r, propColor, false)
-  append(r.output, key)
-  append(r.output, ": ")
-  applyStyle(r, styleBright)
-
-  if valText.find(NewLines) == -1:
-    append(r.output, valText)
-    append(r.output, "\n")
-  else:
-    let indent = textBlockIndent & repeat(' ', key.len + 2)
-    var first = true
-    for line in splitLines(valText):
-      if not first: append(r.output, indent)
-      append(r.output, line)
-      append(r.output, "\n")
-      first = false
-
-  resetColors(r)
-
-template setFirstProperty*(r: var TextBlockRecord, key: string, val: auto) =
-  setProperty(r, key, val)
-
-proc flushRecord*(r: var TextBlockRecord) =
-  append(r.output, "\n")
-  flushOutput(r.output)
-
-#
-# JSON records:
-#
-
-template `[]=`(r: var JsonRecord, key: string, val: auto) =
-  when defined(js):
-    when val is string:
-      r.record[key] = when val is string: cstring(val) else: val
-    else:
-      r.record[key] = val
-  else:
-    writeField(r.jsonWriter, key, val)
-
-proc initLogRecord*(r: var JsonRecord,
-                    level: LogLevel,
-                    topics: string,
-                    name: string) =
-  when defined(js):
-    r.record = newJsObject()
-  else:
-    r.outStream = memoryOutput()
-    r.jsonWriter = Json.Writer.init(r.outStream, pretty = false)
-    r.jsonWriter.beginRecord()
-
-  if level != NONE:
-    r["lvl"] = level.shortName
-
-  when r.timestamps != NoTimestamps:
-    r["ts"] = r.timestamp()
-
-  r["msg"] = name
-
-  if topics.len > 0:
-    r["topics"] = topics
-
-proc setProperty*(r: var JsonRecord, key: string, val: auto) =
-  r[key] = val
-
-template setFirstProperty*(r: var JsonRecord, key: string, val: auto) =
-  r[key] = val
-
-proc flushRecord*(r: var JsonRecord) =
-  when defined(js):
-    r.output.append JSON.stringify(r.record)
-  else:
-    r.jsonWriter.endRecord()
-    r.outStream.write '\n'
-    r.output.append r.outStream.getOutput(string)
-
-  flushOutput r.output
+  s.write shortName(lvl)
+  resetColors(s, colorScheme)
 
 #
 # When any of the output streams have multiple output formats, we need to
@@ -780,27 +638,6 @@ macro logStream*(streamDef: untyped): untyped =
                                      streamCode.recordType,
                                      streamCode.outputsTuple))
 
-macro createStreamRecordTypes: untyped =
-  result = newStmtList()
-
-  for i in 0 ..< config.streams.len:
-    let
-      s = config.streams[i]
-      streamName = newIdentNode(s.name)
-      streamCode = sinkSpecsToCode(streamName, s.sinks)
-
-    result.add getAst(createStreamSymbol(streamName,
-                                         streamCode.recordType,
-                                         streamCode.outputsTuple))
-
-    if i == 0:
-      result.add quote do:
-        template activeChroniclesStream*: typedesc = `streamName`
-
-  # echo result.repr
-
-createStreamRecordTypes()
-
 when defined(windows) and false:
   # This is some experimental code that enables native ANSI color codes
   # support on Windows 10 (it has been confirmed to work, but the feature
@@ -826,3 +663,41 @@ when defined(windows) and false:
     if setConsoleMode(getStdHandle(STD_OUTPUT_HANDLE), mode) != 0:
       discard
       # echo "ANSI MODE ENABLED"
+
+func toModuleName(format: LogFormatPlugin): string =
+  case format.string.toLowerAscii
+  of "json": "chronicles/json_records"
+  of "textlines": "chronicles/textlines"
+  of "textblocks": "chronicles/textblocks"
+  else: string format
+
+macro createStreamRecordTypes: untyped =
+  result = newStmtList()
+  var importedPlugins = newSeq[string]()
+
+  for i in 0 ..< config.streams.len:
+    let stream = config.streams[i]
+
+    for sink in stream.sinks:
+      if importedPlugins.find(sink.format.id) == -1:
+        result.add parseStmt("import $1 as $2\nexport $2" %
+                             [sink.format.toModuleName, sink.format.id])
+        importedPlugins.add sink.format.id
+
+    let
+      streamName = newIdentNode(stream.name)
+      streamCode = sinkSpecsToCode(streamName, stream.sinks)
+
+    result.add getAst(createStreamSymbol(streamName,
+                                         streamCode.recordType,
+                                         streamCode.outputsTuple))
+
+    if i == 0:
+      result.add quote do:
+        template activeChroniclesStream*: typedesc = `streamName`
+
+  when defined(debugLogImpl):
+    echo result.repr
+
+createStreamRecordTypes()
+

--- a/chronicles/std/net.nim
+++ b/chronicles/std/net.nim
@@ -1,0 +1,8 @@
+import
+  std/net,
+  chronicles
+
+chronicles.formatIt(Port):
+  int(it)
+
+export chronicles, net

--- a/chronicles/textblocks.nim
+++ b/chronicles/textblocks.nim
@@ -1,0 +1,126 @@
+import
+  times, strutils, terminal, typetraits,
+  serialization, faststreams/[outputs, textio],
+  log_output, textformats, options
+
+type
+  LogRecord*[OutputKind;
+             timestamps: static[TimestampScheme],
+             colors: static[ColorScheme]] = object
+    output*: OutputStream
+    when stackTracesEnabled:
+      exception*: ref Exception
+
+type
+  SomeTime = Time | DateTime | times.Duration | TimeInterval | Timezone | ZonedTime
+
+const
+  arrayOpenBracket = "[" & newLine
+  arrayCloseBracket = "]" & newLine
+
+const
+  # We work-around a Nim bug:
+  # The compiler claims that the `terminal` module is unused
+  styleBright = terminal.styleBright
+
+proc appendIndent(output: var auto, depthLevel: int) =
+  for i in 0 .. depthLevel:
+    append(output, indentStr)
+
+proc appendFieldName(r: var LogRecord, name: string, depthLevel: int) =
+  appendIndent(r.output, depthLevel)
+  r.setFgColor propColor, false
+  r.output.append name
+  r.output.append ": "
+  r.resetColors()
+
+proc appendValueImpl[T](r: var LogRecord, value: T, depthLevel: int) =
+  mixin formatItIMPL
+
+  setFgColor(r, propColor, false)
+  applyStyle(r, styleBright)
+
+  when value is ref Exception:
+    appendValueImpl(r, value.msg, depthLevel)
+    when stackTracesEnabled:
+      r.exception = value
+
+  elif value is enum:
+    appendText(r, $value)
+    append(r.output, newLine)
+
+  elif value is array|seq:
+    append(r.output, arrayOpenBracket)
+    for value in items(value):
+      appendIndent(r.output, depthLevel + 1)
+      appendValueImpl(r, formatItIMPL(value), depthLevel + 1)
+    appendIndent(r.output, depthLevel)
+    append(r.output, arrayCloseBracket)
+
+  elif value is bool:
+    append(r.output, if value: "true" else: "false")
+    append(r.output, newLine)
+
+  elif value is SomeTime | SomeNumber:
+    appendText(r, value)
+    append(r.output, newLine)
+
+  elif value is object:
+    append(r.output, newLine)
+    enumInstanceSerializedFields(value, fieldName, fieldValue):
+      appendFieldName(r, fieldName, depthLevel + 1)
+      appendValueImpl(r, formatItIMPL(fieldValue), depthLevel + 1)
+
+  elif value is string:
+    var first = true
+    for line in splitLines(value):
+      if not first:
+        appendIndent(r.output, depthLevel)
+      writeEscapedString(r.output, line)
+      append(r.output, newLine)
+      first = false
+
+  else:
+    const typeName = typetraits.name(T)
+    {.fatal: "The textblocks format does not support the '" & typeName & "' type".}
+
+  resetColors(r)
+
+template appendValue(r: var LogRecord, val: auto, depthLevel: int) =
+  mixin formatItIMPL
+  appendValueImpl(r, formatItIMPL val, depthLevel)
+
+proc setProperty*(r: var LogRecord, name: string, value: auto, depthLevel = 0) =
+  appendFieldName(r, name, depthLevel)
+  appendValue(r, value, depthLevel)
+
+proc initLogRecord*(r: var LogRecord,
+                    level: LogLevel,
+                    topics, msg: string) =
+  mixin append
+
+  r.output = initOutputStream type(r)
+
+  appendLogLevelMarker(r, level)
+  writeSpaceAndTs(r)
+
+  append(r.output, " ")
+  applyStyle(r, styleBright)
+  append(r.output, msg)
+  resetColors(r)
+
+  append(r.output, "\n")
+
+  if topics.len > 0:
+    setProperty(r, "topics", topics)
+
+proc flushRecord*(r: var LogRecord) =
+  when stackTracesEnabled:
+    if r.exception != nil:
+      append(r.output, static(indentStr & "--" & newLine))
+      appendStackTrace(r)
+
+  append(r.output, newLine)
+
+  flushOutput r.OutputKind, r.output
+

--- a/chronicles/textformats.nim
+++ b/chronicles/textformats.nim
@@ -1,0 +1,69 @@
+import
+  strutils,
+  faststreams/[outputs, textio],
+  options, log_output
+
+const
+  controlChars =  {'\x00'..'\x1f'}
+  extendedAsciiChars = {'\x7f'..'\xff'}
+  escapedChars*: set[char] = strutils.NewLines + {'"', '\\'} + controlChars + extendedAsciiChars
+  quoteChars*: set[char] = {' ', '='}
+
+func containsEscapedChars*(str: string|cstring): bool =
+  for c in str:
+    if c in escapedChars:
+      return true
+  return false
+
+func needsQuotes*(str: string|cstring): bool =
+  for c in str:
+    if c in quoteChars:
+      return true
+  return false
+
+proc writeEscapedString*(output: OutputStream, str: string|cstring) =
+  for c in str:
+    case c
+    of '"': output.write "\\\""
+    of '\\': output.write "\\\\"
+    of '\r': output.write "\\r"
+    of '\n': output.write "\\n"
+    else:
+      const hexChars = "0123456789abcdef"
+      if c >= char(0x20) and c <= char(0x7e):
+        output.write c
+      else:
+        output.write("\\x")
+        output.write hexChars[int(c) shr 4 and 0xF]
+        output.write hexChars[int(c) and 0xF]
+
+template appendLogLevelMarker*(r: var auto, lvl: LogLevel) =
+  when r.colors != NoColors:
+    let (color, bright) = levelToStyle(lvl)
+    setFgColor(r, color, bright)
+
+  append(r.output, shortName lvl)
+  resetColors(r)
+
+template appendChar*(r: var auto, c: static char) =
+  when r.output is OutputStream:
+    write(r.output, c)
+  else:
+    append(r.output, $c)
+
+template appendText*(r: var auto, value: auto) =
+  when r.output is OutputStream:
+    writeText(r.output, value)
+  else:
+    append(r.output, $value)
+
+proc appendStackTrace*(r: var auto) =
+  for entry in getStackTraceEntries(r.exception):
+    append(r.output, indentStr)
+    appendText(r.output, entry.filename)
+    appendChar(r, '(')
+    appendText(r, entry.line)
+    append(r.output, ") ")
+    appendText(r, entry.procname)
+    append(r.output, newLine)
+

--- a/chronicles/textlines.nim
+++ b/chronicles/textlines.nim
@@ -1,0 +1,152 @@
+import
+  times, strutils, typetraits, terminal,
+  serialization/object_serialization, faststreams/[outputs, textio],
+  options, log_output, textformats
+
+type
+  LogRecord*[OutputKind;
+             timestamps: static[TimestampScheme],
+             colors: static[ColorScheme]] = object
+    output*: OutputStream
+    level: LogLevel
+    when stackTracesEnabled:
+      exception*: ref Exception
+
+const
+  # We work-around a Nim bug:
+  # The compiler claims that the `terminal` module is unused
+  styleBright = terminal.styleBright
+
+proc appendValueImpl[T](r: var LogRecord, value: T) =
+  mixin formatItIMPL
+
+  when value is ref Exception:
+    appendValueImpl(r, value.msg)
+    when stackTracesEnabled:
+      r.exception = value
+
+  elif value is SomeNumber:
+    appendText(r, value)
+
+  elif value is enum:
+    appendText(r, $value)
+
+  elif value is object:
+    appendChar(r, '{')
+    var needsComma = false
+    enumInstanceSerializedFields(value, fieldName, fieldValue):
+      if needsComma: r.output.append ", "
+      append(r.output, fieldName)
+      append(r.output, ": ")
+      appendValueImpl(r, formatItIMPL fieldValue)
+      needsComma = true
+    appendChar(r, '}')
+
+  elif value is tuple:
+    discard
+
+  elif value is bool:
+    append(r.output, if value: "true" else: "false")
+
+  elif value is seq|array:
+    appendChar(r, '[')
+    for index, value in pairs(value):
+      if index > 0: r.output.append ", "
+      appendValueImpl(r, formatItIMPL value)
+    appendChar(r, ']')
+
+  elif value is string|cstring:
+    let
+      needsEscape = containsEscapedChars(value)
+      needsQuote = needsEscape or needsQuotes(value)
+    if needsQuote:
+      appendChar(r, '"')
+      if needsEscape:
+        writeEscapedString(r.output, value)
+      else:
+        r.output.write value
+      appendChar(r, '"')
+    else:
+      r.output.write value
+
+  else:
+    const typeName = typetraits.name(T)
+    {.fatal: "The textlines format does not support the '" & typeName & "' type".}
+
+template appendValue(r: var LogRecord, value: auto) =
+  mixin formatItIMPL
+  appendValueImpl(r, formatItIMPL value)
+
+when false:
+  proc quoteIfNeeded(r: var LogRecord, value: ref Exception) =
+    r.stream.writeText value.name
+    r.stream.writeText '('
+    r.quoteIfNeeded value.msg
+    when not defined(js) and not defined(nimscript) and hostOS != "standalone":
+      r.stream.writeText ", "
+      r.quoteIfNeeded getStackTrace(value).strip
+    r.stream.writeText ')'
+
+proc appendFieldName*(r: var LogRecord, name: string) =
+  mixin append
+  r.output.append " "
+  when r.colors != NoColors:
+    let (color, bright) = levelToStyle(r.level)
+    setFgColor r, color, bright
+  r.output.append name
+  resetColors r
+  r.output.append "="
+
+const
+  # no good way to tell how much padding is going to be needed so we
+  # choose an arbitrary number and use that - should be fine even for
+  # 80-char terminals
+  msgWidth = 42
+  spaces = repeat(' ', msgWidth)
+
+proc initLogRecord*(r: var LogRecord,
+                    level: LogLevel,
+                    topics, msg: string) =
+  r.level = level
+  r.output = initOutputStream type(r)
+
+  # Log level comes first - allows for easy regex match with ^
+  appendLogLevelMarker(r, level)
+
+  writeSpaceAndTs(r)
+
+  let msgLen = msg.len
+  r.output.append " "
+  applyStyle(r, styleBright)
+  if msgLen < msgWidth:
+    r.output.append msg
+    r.output.append spaces.toOpenArray(1, msgWidth - msgLen)
+  else:
+    r.output.append msg.toOpenArray(0, msgWidth - 3)
+    r.output.append ".. "
+
+  resetColors(r)
+
+  if topics.len > 0:
+    r.output.append " topics=\""
+    setFgColor(r, topicsColor, true)
+    r.output.append topics
+    resetColors(r)
+    r.output.append "\""
+
+proc setProperty*(r: var LogRecord, name: string, value: auto) =
+  r.appendFieldName name
+
+  r.setFgColor propColor, true
+  r.appendValue value
+  r.resetColors
+
+proc flushRecord*(r: var LogRecord) =
+  r.output.append "\n"
+
+  when stackTracesEnabled:
+    if r.exception != nil:
+      appendStackTrace(r)
+
+  flushOutput r.OutputKind, r.output
+

--- a/tests/dynamic_scopes.nim
+++ b/tests/dynamic_scopes.nim
@@ -9,6 +9,8 @@ type
 proc `$`*(t: Seconds): string = $(t.int) & "s"
 proc `%`*(t: Seconds): string = $(t.int)
 
+chronicles.formatIt Seconds: $it
+
 proc main =
   dynamicLogScope(reqId = 10, userId = 20):
     info "test"

--- a/tests/logging_objects.nim
+++ b/tests/logging_objects.nim
@@ -1,0 +1,40 @@
+import
+  strutils, chronicles
+
+type
+  Point = object
+    x, y: float
+
+  Triangle = object
+    a, b, c: Point
+    color: Color
+
+  Color = object
+    r, g, b: int
+
+logScope:
+  c = Color(r: 12, g: 32, b: 46)
+
+proc main() {.raises: [Defect].} =
+  logScope:
+    topics = "main"
+
+  var
+    a = Point(x: 0, y: 10)
+    b = Point(x: 12, y: 32)
+    c = Point(x: 15, y: 21)
+    red = Color(r: 255)
+
+    t = Triangle(a: a, b: b, c: c, color: red)
+
+  try:
+    info "main started", triangle = t, hasBlue = (t.color.b > 0)
+    let y = parseInt("abcd")
+    info "next line", x = "test", y
+  except CatchableError as err:
+    error "Failure", err = err.msg
+
+main()
+
+info("exiting", message = "bye bye")
+

--- a/tests/size.nim
+++ b/tests/size.nim
@@ -1,1003 +1,1004 @@
 import chronicles
 
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
-info "hello", a=1, b=2, c=3, d=4, e=5
+for i in 0..100:
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
+  info "hello", a=1, b=2, c=3, d=4, e=5
 


### PR DESCRIPTION
* Log levels can be specified per sink

* When a log statements logs an exception, the stack trace of the
  exception will be printed in a more readable form (on multople
  indented lines with one call stack entry per line).
  The feature is enabled only in debug builds or when explicitly
  requested with `-d:chronicles_stack_traces:on`.

* The printing of complex objects in the formats `textlines` and `textblocks`
  has been improved. Type-specific overrides such as `chronicles.formatIt`
  will now affect the formatting of the object fields.

* Most log statements won't perform any allocations.
  The details depend on the logged object types.

* The type of line ending characters used by Chronicles can be
  controlled with `-d:chronicles_line_endings`. Supported values
  are 'windows', 'posix` and 'platform'.