### PR TITLE
update color scheme

### DIFF
--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -459,7 +459,7 @@ template levelToStyle(lvl: LogLevel): untyped =
   # Bright Black is gray
   # Light green doesn't display well on white consoles
   # Light yellow doesn't display well on white consoles
-  # Light gyan is darker than green
+  # Light cyan is darker than green
 
   case lvl
   of TRACE: (fgBlack, true)   # Bright Black is gray

--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -456,14 +456,19 @@ template applyStyle(record, style) =
     setStyle(getOutputStream(record.output), {style})
 
 template levelToStyle(lvl: LogLevel): untyped =
+  # Bright Black is gray
+  # Light green doesn't display well on white consoles
+  # Light yellow doesn't display well on white consoles
+  # Light gyan is darker than green
+
   case lvl
-  of TRACE: (fgGreen, true)
-  of DEBUG: (fgGreen, true)
+  of TRACE: (fgBlack, true)   # Bright Black is gray
+  of DEBUG: (fgCyan, false)
   of INFO:  (fgGreen, false)
-  of NOTICE:(fgYellow, false)
-  of WARN:  (fgYellow, true)
-  of ERROR: (fgRed, false)
-  of FATAL: (fgRed, true)
+  of NOTICE:(fgMagenta, true)
+  of WARN:  (fgYellow, false)
+  of ERROR: (fgRed, true)
+  of FATAL: (fgRed, false)
   of NONE:  (fgWhite, false)
 
 template shortName(lvl: LogLevel): string =

--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -462,10 +462,10 @@ template levelToStyle(lvl: LogLevel): untyped =
   # Light cyan is darker than green
 
   case lvl
-  of TRACE: (fgBlack, true)   # Bright Black is gray
-  of DEBUG: (fgCyan, false)
-  of INFO:  (fgGreen, false)
-  of NOTICE:(fgMagenta, true)
+  of TRACE: (fgWhite, false)
+  of DEBUG: (fgBlack, true) # Bright Black is gray
+  of INFO:  (fgCyan, true)
+  of NOTICE:(fgMagenta, false)
   of WARN:  (fgYellow, false)
   of ERROR: (fgRed, true)
   of FATAL: (fgRed, false)


### PR DESCRIPTION
This is a bikeshedding proposal on a new color scheme.
The most important part is not making NOTICE look like a warning.

In Debug mode
![image](https://user-images.githubusercontent.com/22738317/94842269-7cd69d80-041b-11eb-8e62-5334febee0fe.png)

In Trace mode
![2020-10-01_19-16](https://user-images.githubusercontent.com/22738317/94842344-911a9a80-041b-11eb-9ec8-ebcb5abb2695.png)

Opinion:
- The gray might also be used for debug, but I then don't have a good color for trace. White is too eye-catching/bright for a log level as noisy as this.
- DBG and INF might be not contrasted enough which might make us miss INFO level. But blue is kind of taken by the log content.

References:
- https://github.com/status-im/nim-beacon-chain/issues/1779
- https://github.com/status-im/nim-beacon-chain/issues/1785
- https://github.com/status-im/nim-beacon-chain/pull/1788