### PR TITLE
fixes #92, workaround for spurious Exception raised on Windows

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -366,13 +366,23 @@ template logFn(name: untyped, severity: typed, debug=false) {.dirty.} =
     wrapSideEffects(debug):
       log(instantiationInfo(), stream, severity, eventName, props)
 
-logFn trace , LogLevel.TRACE, debug=true
-logFn debug , LogLevel.DEBUG
-logFn info  , LogLevel.INFO
-logFn notice, LogLevel.NOTICE
-logFn warn  , LogLevel.WARN
-logFn error , LogLevel.ERROR
-logFn fatal , LogLevel.FATAL
+# workaround for https://github.com/status-im/nim-chronicles/issues/92
+when defined(windows) and (NimMajor, NimMinor, NimPatch) < (1, 4, 4):
+  logFn trace , LogLevel.TRACE, debug=true
+  logFn debug , LogLevel.DEBUG, debug=true
+  logFn info  , LogLevel.INFO, debug=true
+  logFn notice, LogLevel.NOTICE, debug=true
+  logFn warn  , LogLevel.WARN, debug=true
+  logFn error , LogLevel.ERROR, debug=true
+  logFn fatal , LogLevel.FATAL, debug=true
+else:
+  logFn trace , LogLevel.TRACE, debug=true
+  logFn debug , LogLevel.DEBUG
+  logFn info  , LogLevel.INFO
+  logFn notice, LogLevel.NOTICE
+  logFn warn  , LogLevel.WARN
+  logFn error , LogLevel.ERROR
+  logFn fatal , LogLevel.FATAL
 
 # TODO:
 #

--- a/tests/no_side_effect.nim
+++ b/tests/no_side_effect.nim
@@ -4,3 +4,9 @@ func main =
   trace "effect-free"
 
 main()
+
+# issue #92
+proc test() {.raises: [Defect].} =
+  error "should not raises exception"
+
+test()


### PR DESCRIPTION
regarding the linux 32bit CI failing in github actions, it is because github update it's ubuntu image from 20201210.0 to 20210309.1
and it has problem when downloading `libssl-dev:i386` which in turn used by `nimble` to load `libcrypto.so`.