### PR TITLE
Fix registry locking when threading disabled

### DIFF
--- a/chronicles/topics_registry.nim
+++ b/chronicles/topics_registry.nim
@@ -34,7 +34,7 @@ template lockRegistry(body: untyped) =
   when compileOption("threads"):
     withLock registryLock: body
   else:
-    body
+    {.locks: [registryLock].}: body
 
 proc setLogLevel*(lvl: LogLevel) =
   lockRegistry:


### PR DESCRIPTION
In #46 a regression got introduced that leads to compilation errors when
attempting to change the active log level or topics configuration in the
case of compiling without the `--threads:on` option.

```
  Error: unguarded access: gActiveLogLevel
```

This is because the global registry lock is not being acquired when the
`--threads:on` option is disabled. However, without threading it is not
necessary to actually acquire a lock. Therefore, this patch silences the
error by annotating relevant code with the `locks` pragma to assert that
the lock is being manually managed.