### PR TITLE
chronicles_enabled_topics wildcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,14 +303,14 @@ logging statements will be erased at compile-time from the final code.
 When the list includes multiple topics, any of them is considered a match.
 
 > In both contexts, the list of topics is written as a comma or space-separated
-string of case-sensitive topic names.
+string of case-sensitive topic names, supporting wildcard matching.
 
 In the list of topics, you can also optionally provide a log level after the
 topic, separated with a colon from the topic. If a log level is provided it will
 overrule the `chronicles_log_level` setting. The log level can be defined as
 `LogLevel` values or directly as the corresponding integer values.
 
-e.g. `-d:chronicles_enabled_topics:MyTopic:DEBUG,AnotherTopic:5`
+e.g. `-d:chronicles_enabled_topics:MyTopic:DEBUG,TopicsStartingWith*:5`
 
 ### chronicles_required_topics
 

--- a/chronicles.nim
+++ b/chronicles.nim
@@ -215,6 +215,27 @@ macro expandIt*(T: type, expandedProps: untyped): untyped =
   when defined(debugLogImpl):
     echo result.repr
 
+proc wildcard(str, match: string): bool =
+  var strIndex = 0
+
+  for matchIndex, ch in match:
+    if str.len <= strIndex: return false
+
+    if ch == '?':
+      strIndex.inc()
+      continue
+    elif ch == '*':
+      while strIndex < str.len:
+        if wildcard(str[strIndex ..< ^0], match[matchIndex + 1 .. ^1]):
+          return true
+        strIndex.inc()
+    elif ch == str[strIndex]:
+      strIndex.inc()
+    else:
+      return false
+
+  return strIndex == str.len
+
 macro logIMPL(lineInfo: static InstInfo,
               Stream: typed,
               RecordType: type,
@@ -258,7 +279,7 @@ macro logIMPL(lineInfo: static InstInfo,
         return
       else:
         for topic in enabledTopics:
-          if topic.name == t:
+          if wildcard(t, topic.name):
             if topic.logLevel != NONE:
               if severity >= topic.logLevel:
                 enabledTopicsMatch = true

--- a/tests/topics/enabled_wildcard.test
+++ b/tests/topics/enabled_wildcard.test
@@ -1,0 +1,17 @@
+program="../topics_and_loglvls"
+chronicles_sinks="textlines[stdout]"
+chronicles_colors=None
+chronicles_timestamps=None
+chronicles_log_level=TRACE
+chronicles_enabled_topics="*:INFO foo:TRACE"
+[Output]
+stdout="""WRN inside main                                topics="main" tid=32613 b=10 arg=50 a=1
+INF inside main                                topics="main" tid=32613 b=10 arg=50 a=1
+WRN inside foo                                 topics="foo" tid=32613 b=10 arg=10
+INF inside foo                                 topics="foo" tid=32613 b=10 arg=10
+DBG inside foo                                 topics="foo" tid=32613 b=10 arg=10
+WRN inside foobar                              topics="foo bar" tid=32613 b=10 arg=20
+INF inside foobar                              topics="foo bar" tid=32613 b=10 arg=20
+DBG inside foobar                              topics="foo bar" tid=32613 b=10 arg=20
+INF after main                                 topics="general" tid=32613
+"""


### PR DESCRIPTION
Useful for `chronicles_enabled_topics="*:INFO foo:TRACE"`