### PR TITLE
alternative `BareExcept` fix

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -346,12 +346,8 @@ template log*(lineInfo: static InstInfo,
 template wrapSideEffects(debug: bool, body: untyped) {.inject.} =
   when debug:
     {.noSideEffect.}:
-      when (NimMajor, NimMinor) >= (1, 6):
-        {.warning[BareExcept]:off.}
       try: body
-      except: discard
-      when (NimMajor, NimMinor) >= (1, 6):
-        {.warning[BareExcept]:on.}
+      except CatchableError: discard
   else:
     body
 


### PR DESCRIPTION
1) `when (NimMajor, NimMinor) >= (1, 6)` is incorrect anyway. Needs to change somehow. Nim 1.6.0 through 1.6.10 do not know about `BareExcept` and either will error on attempts to compile `master` as is, or there are deeper bugs in this code's accessibility.

2) Also, not clear why in this particular instance that `except CatchableError`, which is the minimal non-kludgy fix, is incorrect.

3) Current approach results in https://github.com/status-im/nim-chronicles/issues/127