### PR TITLE
feat: allow string input for setLogLevel

### DIFF
--- a/chronicles/topics_registry.nim
+++ b/chronicles/topics_registry.nim
@@ -1,4 +1,4 @@
-import locks, macros, tables
+import locks, macros, tables, strutils
 from options import LogLevel
 
 export
@@ -39,6 +39,10 @@ template lockRegistry(body: untyped) =
 proc setLogLevel*(lvl: LogLevel) =
   lockRegistry:
     gActiveLogLevel = lvl
+
+proc setLogLevel*(lvl: string) =
+  lockRegistry:
+    gActiveLogLevel = parseEnum[LogLevel](lvl.toUpperAscii)
 
 proc clearTopicsRegistry* =
   lockRegistry:

--- a/tests/runtime_filtering.nim
+++ b/tests/runtime_filtering.nim
@@ -86,3 +86,12 @@ echo setTopicState("bar", Normal)
 
 foo()
 bar()
+
+echo "> set global LogLevel to string warn, set main and foo to INFO, both should print:"
+setLogLevel("warn")
+echo setTopicState("main", Normal, INFO)
+echo setTopicState("foo", Normal, INFO)
+echo setTopicState("bar", Normal)
+
+foo()
+bar()


### PR DESCRIPTION
If you use `parseTopicDirectives` then it allows to use log levels as strings which can be lowercased or even shortened. But if you want to set top-level logging level then you have to use the `parseEnum` utility which is IMHO bad API, so I want to introduce another override for `setLogLevel` which allows to take string in any casing.