### PR TITLE
suppress some more `IOError` when logging

### DIFF
--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -439,7 +439,10 @@ template writeTs(record) =
 
 template fgColor(record, color, brightness) =
   when record.colors == AnsiColors:
-    append(record.output, ansiForegroundColorCode(color, brightness))
+    try:
+      append(record.output, ansiForegroundColorCode(color, brightness))
+    except ValueError:
+      discard
   elif record.colors == NativeColors:
     setForegroundColor(getOutputStream(record.output), color, brightness)
 
@@ -548,7 +551,8 @@ proc initLogRecord*(r: var TextLineRecord,
   r.level = lvl
   appendHeader(r, lvl, topics, name, true)
 
-proc setProperty*(r: var TextLineRecord, key: string, val: auto) =
+proc setProperty*(
+    r: var TextLineRecord, key: string, val: auto) {.raises: [].} =
   append(r.output, " ")
   let valText = $val
 
@@ -608,7 +612,8 @@ proc initLogRecord*(r: var TextBlockRecord,
   appendHeader(r, level, topics, name, false)
   append(r.output, "\n")
 
-proc setProperty*(r: var TextBlockRecord, key: string, val: auto) =
+proc setProperty*(
+    r: var TextBlockRecord, key: string, val: auto) {.raises: [].} =
   let valText = $val
 
   append(r.output, textBlockIndent)
@@ -649,7 +654,10 @@ template `[]=`(r: var JsonRecord, key: string, val: auto) =
     else:
       r.record[key] = val
   else:
-    writeField(r.jsonWriter, key, val)
+    try:
+      writeField(r.jsonWriter, key, val)
+    except IOError:
+      discard
 
 proc initLogRecord*(r: var JsonRecord,
                     level: LogLevel,
@@ -673,7 +681,7 @@ proc initLogRecord*(r: var JsonRecord,
   if topics.len > 0:
     r["topics"] = topics
 
-proc setProperty*(r: var JsonRecord, key: string, val: auto) =
+proc setProperty*(r: var JsonRecord, key: string, val: auto) {.raises: [].} =
   r[key] = val
 
 template setFirstProperty*(r: var JsonRecord, key: string, val: auto) =

--- a/tests/perf/size_check_debug.test
+++ b/tests/perf/size_check_debug.test
@@ -1,5 +1,5 @@
 program="../size"
-max_size=1400000
+max_size=1500000
 
 chronicles_sinks="textlines[stdout]"
 chronicles_colors=AnsiColors


### PR DESCRIPTION
Nim 2.0 highlighted some more situations where logging may raise an `IOError`. Suppress those as well to compile applications in Nim 2.0.