### PR TITLE
fix chronos v4 compatiblity

### DIFF
--- a/chronicles/chronos_tools.nim
+++ b/chronicles/chronos_tools.nim
@@ -11,12 +11,5 @@ proc catchOrQuit*(error: Exception) =
 
 proc traceAsyncErrors*(fut: FutureBase) =
   fut.addCallback do (arg: pointer):
-    if not fut.error.isNil:
+    if fut.failed():
       catchOrQuit fut.error[]
-
-template traceAwaitErrors*(fut: FutureBase) =
-  let f = fut
-  yield f
-  if not f.error.isNil:
-    catchOrQuit f.error[]
-


### PR DESCRIPTION
`yield` has never worked correctly in chronos - removing broken function.

Also, the "official" way of checking the state of the future is via `failed`