### PR TITLE
abbreviate `NOTICE` with `NTC` instead of `NOT`

### DIFF
--- a/chronicles/helpers.nim
+++ b/chronicles/helpers.nim
@@ -33,7 +33,7 @@ func parseTopicDirectives*(directives: openArray[string]): Table[string, TopicSe
         forEachTopic: topic.logLevel = DEBUG
       of "inf", "info":
         forEachTopic: topic.logLevel = INFO
-      of "not", "notice":
+      of "ntc", "notice", #[legacy compatibility:]# "not":
         forEachTopic: topic.logLevel = NOTICE
       of "wrn", "warn":
         forEachTopic: topic.logLevel = WARN
@@ -43,4 +43,3 @@ func parseTopicDirectives*(directives: openArray[string]): Table[string, TopicSe
         forEachTopic: topic.logLevel = FATAL
       else:
         raise newException(ValueError, &"'{parts[0]}' is not a recognized log level.")
-

--- a/chronicles/log_output.nim
+++ b/chronicles/log_output.nim
@@ -480,7 +480,7 @@ template shortName(lvl: LogLevel): string =
   of TRACE: "TRC"
   of DEBUG: "DBG"
   of INFO:  "INF"
-  of NOTICE:"NOT"
+  of NOTICE:"NTC"  # Legacy: "NOT"
   of WARN:  "WRN"
   of ERROR: "ERR"
   of FATAL: "FAT"


### PR DESCRIPTION
The existing `NOT` abbreviation when logging at `NOTICE` level may be confusing. Proposing to change the abbreviation to `NTC` instead.