### PR TITLE
fix `ImplicitTemplateRedefinition` warning

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -72,7 +72,7 @@ macro logScopeIMPL(prevScopes: typed,
 
   let activeScope = id("activeChroniclesScope", isPublic)
   result.add quote do:
-    template `activeScope` {.used.} =
+    template `activeScope` {.redefine, used.} =
       `newRevision`
       `newAssingments`
 

--- a/chronicles.nim
+++ b/chronicles.nim
@@ -71,10 +71,16 @@ macro logScopeIMPL(prevScopes: typed,
     result.add chroniclesExportNode
 
   let activeScope = id("activeChroniclesScope", isPublic)
-  result.add quote do:
-    template `activeScope` {.redefine, used.} =
-      `newRevision`
-      `newAssingments`
+  when NimMajor >= 2:
+    result.add quote do:
+      template `activeScope` {.redefine, used.} =
+        `newRevision`
+        `newAssingments`
+  else:
+    result.add quote do:
+      template `activeScope` {.used.} =
+        `newRevision`
+        `newAssingments`
 
 template logScope*(newBindings: untyped) {.dirty.} =
   bind bindSym, logScopeIMPL, brForceOpen

--- a/chronicles.nim
+++ b/chronicles.nim
@@ -71,7 +71,7 @@ macro logScopeIMPL(prevScopes: typed,
     result.add chroniclesExportNode
 
   let activeScope = id("activeChroniclesScope", isPublic)
-  when NimMajor >= 2:
+  when defined(nimHasTemplateRedefinitionPragma):
     result.add quote do:
       template `activeScope` {.redefine, used.} =
         `newRevision`


### PR DESCRIPTION
Otherwise it spams the build with:
```
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(29, 20) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(85, 10) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(56, 3) template/generic instantiation of `logScope` from here
nimbus-eth2/vendor/nim-chronicles/chronicles.nim(74, 14) Warning: template 'activeChroniclesScope' is implicitly redefined; this is deprecated, add an explicit .redefine pragma [ImplicitTemplateRedefinition]
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(29, 20) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(85, 10) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(56, 3) template/generic instantiation of `logScope` from here
nimbus-eth2/vendor/nim-chronicles/chronicles.nim(74, 14) Warning: template 'activeChroniclesScope' is implicitly redefined; this is deprecated, add an explicit .redefine pragma [ImplicitTemplateRedefinition]
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(90, 6) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(149, 10) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(122, 3) template/generic instantiation of `logScope` from here
nimbus-eth2/vendor/nim-chronicles/chronicles.nim(74, 14) Warning: template 'activeChroniclesScope' is implicitly redefined; this is deprecated, add an explicit .redefine pragma [ImplicitTemplateRedefinition]
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(90, 6) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(149, 10) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validator_client/attestation_service.nim(122, 3) template/generic instantiation of `logScope` from here
nimbus-eth2/vendor/nim-chronicles/chronicles.nim(74, 14) Warning: template 'activeChroniclesScope' is implicitly redefined; this is deprecated, add an explicit .redefine pragma [ImplicitTemplateRedefinition]
nimbus-eth2/beacon_chain/validator_client/sync_committee_service.nim(33, 6) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validator_client/sync_committee_service.nim(92, 3) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validator_client/sync_committee_service.nim(59, 3) template/generic instantiation of `logScope` from here
nimbus-eth2/vendor/nim-chronicles/chronicles.nim(74, 14) Warning: template 'activeChroniclesScope' is implicitly redefined; this is deprecated, add an explicit .redefine pragma [ImplicitTemplateRedefinition]
nimbus-eth2/beacon_chain/validator_client/sync_committee_service.nim(33, 6) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validator_client/sync_committee_service.nim(92, 3) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validator_client/sync_committee_service.nim(59, 3) template/generic instantiation of `logScope` from here
nimbus-eth2/vendor/nim-chronicles/chronicles.nim(74, 14) Warning: template 'activeChroniclesScope' is implicitly redefined; this is deprecated, add an explicit .redefine pragma [ImplicitTemplateRedefinition]
```
et cetera