### PR TITLE
update required Nim version and bump the version

### DIFF
--- a/chronicles.nimble
+++ b/chronicles.nimble
@@ -1,19 +1,16 @@
 mode = ScriptMode.Verbose
 
 packageName   = "chronicles"
-version       = "0.10.3"
+version       = "0.11.0"
 author        = "Status Research & Development GmbH"
 description   = "A crafty implementation of structured logging for Nim"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.6.0"
+requires "nim >= 2.0.16"
 requires "json_serialization"
 
-when NimMajor >= 2:
-  taskRequires "test", "testutils"
-else:
-  requires "testutils"
+taskRequires "test", "testutils"
 
 task test, "run CPU tests":
   when defined(windows):


### PR DESCRIPTION
As stated in #158, the custom pragma breaks the compatibility with Nim 1.6.x.

This fixes the required Nim version and also does the version bump, so that users of Nim 1.6 can still use chronicles 0.10.x.