### PR TITLE
Remove global lock from logging flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ will look like this:
 
 ![json format example](media/json.png)
 
-At first, switching to JSON may look like a daunting proposition, but
-Chronicles provides a customized log tailing program called `chronicles-tail`
-which is able to transform the JSON stream back into the familiar human-readable
-form, while also providing additional advanced features such as on on-the-fly
-filtering, sound alerts and more.
-
 The main advantage of using JSON logging is that this facilitates the storage
 of the log records in specialized databases which are usually able to provide
 search and filtering capabilities and allow you to compute various aggregated

--- a/chronicles/topics_registry.nim
+++ b/chronicles/topics_registry.nim
@@ -1,10 +1,10 @@
 {.push raises: [].}
 
-import std/[locks, tables], stew/shims/macros
+import std/[atomics, locks, tables], stew/shims/macros
 
 from options import config, LogLevel, runtimeFilteringEnabled
 
-export LogLevel
+export atomics, LogLevel
 
 const totalSinks* = block:
   var total = 0
@@ -24,24 +24,43 @@ type
     Disabled
 
   SinkTopicSettings* = object
-    state*: TopicState
-    logLevel*: LogLevel
+    state: Atomic[TopicState]
+    logLevel: Atomic[LogLevel]
 
   TopicSettings* = array[totalSinks, SinkTopicSettings]
 
   SinkFilteringState = object
-    activeLogLevel: LogLevel
-    totalEnabledTopics: int
-    totalRequiredTopics: int
+    activeLogLevel: Atomic[LogLevel]
+    totalEnabledTopics: Atomic[int]
+    totalRequiredTopics: Atomic[int]
 
   RuntimeConfig* = object
     sinkStates: array[totalSinks, SinkFilteringState]
 
   SinksBitmask* = uint8
 
+# moRelaxed is safe since there is no need to coordinate topic state updates
+# between threads other than ensuring the counting is correct / atomic
+
+template state*(s: SinkTopicSettings): TopicState =
+  # TODO https://github.com/nim-lang/Nim/pull/23767
+  let tmp = addr s.state
+  tmp[].load(moRelaxed)
+
+template `state=`*(s: var SinkTopicSettings, v: TopicState) =
+  s.state.store(v, moRelaxed)
+
+template logLevel*(s: SinkTopicSettings): LogLevel =
+  # TODO https://github.com/nim-lang/Nim/pull/23767
+  let tmp = addr s.logLevel
+  tmp[].load(moRelaxed)
+
+template `logLevel=`*(s: var SinkTopicSettings, v: LogLevel) =
+  s.logLevel.store(v, moRelaxed)
+
 var
   registryLock: Lock
-  runtimeConfig {.guard: registryLock.}: RuntimeConfig
+  runtimeConfig: RuntimeConfig
   gTopicStates {.guard: registryLock.}: Table[string, ptr TopicSettings]
 
 when compileOption("threads"):
@@ -58,25 +77,23 @@ template lockRegistry(body: untyped) =
       body
 
 proc setLogLevel*(lvl: LogLevel) =
-  lockRegistry:
-    for sink in mitems(runtimeConfig.sinkStates):
-      sink.activeLogLevel = lvl
+  for sink in mitems(runtimeConfig.sinkStates):
+    sink.activeLogLevel.store(lvl)
 
 proc setLogLevel*(lvl: LogLevel, sinkIdx: int) =
-  lockRegistry:
-    if sinkIdx < runtimeConfig.sinkStates.len:
-      runtimeConfig.sinkStates[sinkIdx].activeLogLevel = lvl
+  if sinkIdx < runtimeConfig.sinkStates.len:
+    runtimeConfig.sinkStates[sinkIdx].activeLogLevel.store(lvl)
 
 # Used only in chronicles-tail
 proc clearTopicsRegistry*() =
   lockRegistry:
     for sink in mitems(runtimeConfig.sinkStates):
-      sink.totalEnabledTopics = 0
-      sink.totalRequiredTopics = 0
+      sink.totalEnabledTopics.store(0)
+      sink.totalRequiredTopics.store(0)
 
     for name, topicSinksSettings in mpairs(gTopicStates):
       for topic in mitems(topicSinksSettings[]):
-        topic.state = Normal
+        topic.state.store(Normal)
 
 proc registerTopic*(name: string, topic: ptr TopicSettings): ptr TopicSettings =
   # As long as sequences are thread-local, modifying the `gTopicStates`
@@ -103,24 +120,27 @@ proc setTopicState*(
       template topicState(): auto =
         topicPtr[][][sinkIdx]
 
-      case topicState.state
-      of Enabled:
-        dec sinkState.totalEnabledTopics
-      of Required:
-        dec sinkState.totalRequiredTopics
-      else:
-        discard
+      let oldState = topicState.state.load(moRelaxed)
 
-      case newState
-      of Enabled:
-        inc sinkState.totalEnabledTopics
-      of Required:
-        inc sinkState.totalRequiredTopics
-      else:
-        discard
+      if oldState != newState:
+        case oldState
+        of Enabled:
+          sinkState.totalEnabledTopics -= 1
+        of Required:
+          sinkState.totalRequiredTopics -= 1
+        else:
+          discard
 
-      topicState.state = newState
-      topicState.logLevel = logLevel
+        case newState
+        of Enabled:
+          sinkState.totalEnabledTopics += 1
+        of Required:
+          sinkState.totalRequiredTopics += 1
+        else:
+          discard
+
+        topicState.state.store(newState)
+      topicState.logLevel.store(logLevel)
 
       return true
     do:
@@ -137,50 +157,51 @@ proc setBit(x: var SinksBitmask, bitIdx: int, bitValue: bool) =
   x = x or (SinksBitmask(bitValue) shl bitIdx)
 
 proc topicsMatch*(
-    logStmtLevel: LogLevel, logStmtTopics: openArray[ptr TopicSettings],
+    logStmtLevel: LogLevel, logStmtTopics: openArray[ptr TopicSettings]
 ): SinksBitmask =
-  lockRegistry:
-    for sinkIdx {.inject.} in 0 ..< totalSinks:
-      template sinkState(): auto =
-        runtimeConfig.sinkStates[sinkIdx]
+  for sinkIdx {.inject.} in 0 ..< totalSinks:
+    template sinkState(): auto =
+      runtimeConfig.sinkStates[sinkIdx]
 
-      var
-        hasEnabledTopics = sinkState.totalEnabledTopics > 0
-        enabledTopicsMatch = false
-        disabled = false
-        normalTopicsMatch = logStmtTopics.len == 0 and  logStmtLevel >= sinkState.activeLogLevel
-        requiredTopicsCount = sinkState.totalRequiredTopics
+    let
+      hasEnabledTopics = sinkState.totalEnabledTopics.load(moRelaxed) > 0
+      activeLogLevel = sinkState.activeLogLevel.load(moRelaxed)
 
-      for topic in logStmtTopics:
-        template topicState(): auto =
-          topic[][sinkIdx]
+    var
+      enabledTopicsMatch = false
+      disabled = false
+      normalTopicsMatch = logStmtTopics.len == 0 and logStmtLevel >= activeLogLevel
+      requiredTopicsCount = sinkState.totalRequiredTopics.load(moRelaxed)
 
-        let topicLogLevel =
-          if topicState.logLevel != LogLevel.NONE:
-            topicState.logLevel
-          else:
-            sinkState.activeLogLevel
+    for topic in logStmtTopics:
+      template topicState(): auto =
+        topic[][sinkIdx]
 
-        if logStmtLevel >= topicLogLevel:
-          case topicState.state
-          of Normal:
-            normalTopicsMatch = true
-          of Enabled:
-            enabledTopicsMatch = true
-          of Disabled:
-            disabled = true
-            break
-          of Required:
-            normalTopicsMatch = true
-            dec requiredTopicsCount
+      let
+        topicStateLevel = topicState.logLevel.load(moRelaxed)
+        topicLogLevel =
+          if topicStateLevel != LogLevel.NONE: topicStateLevel else: activeLogLevel
 
-      if requiredTopicsCount > 0 or disabled:
-        continue
+      if logStmtLevel >= topicLogLevel:
+        case topicState.state.load(moRelaxed)
+        of Normal:
+          normalTopicsMatch = true
+        of Enabled:
+          enabledTopicsMatch = true
+        of Disabled:
+          disabled = true
+          break
+        of Required:
+          normalTopicsMatch = true
+          dec requiredTopicsCount
 
-      if hasEnabledTopics and not enabledTopicsMatch:
-        continue
+    if requiredTopicsCount > 0 or disabled:
+      continue
 
-      result.setBit(sinkIdx, normalTopicsMatch)
+    if hasEnabledTopics and not enabledTopicsMatch:
+      continue
+
+    result.setBit(sinkIdx, normalTopicsMatch)
 
 proc getTopicState*(topic: string): ptr TopicSettings =
   lockRegistry:


### PR DESCRIPTION
Since topic state storage is known at compile time and accessed by pointer, there's no need to coordinate updates beyond letting the compiler know that cross-thread updates can happen.

The worst thing that can happen is that a topic gets matched during an update which seems like a fair tradeoff for avoiding the lock.