### PR TITLE
v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,10 @@ the default automatically:
 A `dynamic` output redirects all logged messages to a closure supplied by
 the host application. Similar to working with file ouputs [file outputs](#working-with-file-outputs),
 you can use the `output` and `outputs` properties of a Chronicles stream
-to specify a gcsafe closure:
+to specify a gcsafe closure that will be called from any thread that does
+logging.
+
+Assuming you have a single dynamic output (`-d:chronicles_sinks=dynamic`):
 
 ```nim
 defaultChroniclesStream.output.writer =

--- a/chronicles.nimble
+++ b/chronicles.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "chronicles"
-version       = "0.11.0"
+version       = "0.12.0"
 author        = "Status Research & Development GmbH"
 description   = "A crafty implementation of structured logging for Nim"
 license       = "Apache License 2.0"


### PR DESCRIPTION
* Auto-detection of colors in terminal and via NO_COLOR
* Improved custom log format support that can be plugged into the compile-time options framework
* Per-sink filtering - each configured log format can now individually be enabled and filtered efficiently, so if you want both text and json support, this no longer causes runtime overhead when only one of them is enabled
* Memory optimizations meaning that most logging happens with few, if any, allocations (when coupled with faststreams 0.4) - since most log lines are short, we can fit them in a small thread-local buffer
* Native line endings
* Smaller `import` list when not using a particular format, ie no longer imports `json_serialization` when only using `textlines`