### PR TITLE
Add missing `severity < enabledLogLevel` check in logIMPL

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -190,7 +190,7 @@ macro logIMPL(lineInfo: static InstInfo,
 
   result = newStmtList()
 
-  if not loggingEnabled or severity < enabledLogLevel:
+  template silenceCompilerWarning() =
     # This statement is to silence compiler warnings
     # `declared but not used` when there is no logging code generated.
     # push/pop pragma pairs cannot be used in this situation
@@ -199,6 +199,8 @@ macro logIMPL(lineInfo: static InstInfo,
     for k, v in finalBindings:
       result.add quote do: chroniclesUsedMagic(`v`)
 
+  if not loggingEnabled:
+    silenceCompilerWarning()
     return
 
   # This is the compile-time topic filtering code, which has a similar
@@ -233,6 +235,7 @@ macro logIMPL(lineInfo: static InstInfo,
           dec requiredTopicsCount
 
   if severity != NONE and not enabledTopicsMatch or requiredTopicsCount > 0:
+    silenceCompilerWarning()
     return
 
   proc lookForScopeOverride(option: var bool, overrideName: string) =


### PR DESCRIPTION
Because of the missing check, spurious declared not used warning appear everywhere when compiling nimbus-eth1.