### PR TITLE
remove macos-13 from the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           - os: linux
             cpu: i386
           - os: macos
-            cpu: amd64
-          - os: macos
             cpu: arm64
           - os: windows
             cpu: amd64
@@ -27,11 +25,6 @@ jobs:
           - target:
               os: linux
             builder: ubuntu-latest
-            shell: bash
-          - target:
-              os: macos
-              cpu: amd64
-            builder: macos-13
             shell: bash
           - target:
               os: macos

--- a/tests/perf/release_opt_size.test
+++ b/tests/perf/release_opt_size.test
@@ -4,7 +4,7 @@ chronicles_colors=None
 chronicles_timestamps=None
 chronicles_thread_ids=None
 chronicles_line_endings=Posix
-max_size=450000
+max_size=500000
 release
 --opt:size
 


### PR DESCRIPTION
It is no longer supported, starting from September 1st: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down