### PR TITLE
Mark log arguments as used when logging is disabled

### DIFF
--- a/chronicles.nim
+++ b/chronicles.nim
@@ -208,10 +208,6 @@ macro logIMPL(lineInfo: static InstInfo,
     for k, v in finalBindings:
       result.add quote do: chroniclesUsedMagic(`v`)
 
-  if not loggingEnabled:
-    silenceCompilerWarning()
-    return
-
   when loggingEnabled:
     # This is the compile-time topic filtering code, which has a similar
     # logic to the generated run-time filtering code:
@@ -335,16 +331,21 @@ macro logIMPL(lineInfo: static InstInfo,
 
     when defined(debugLogImpl):
       echo result.repr
+  else:
+    silenceCompilerWarning()
 
 # Translate all the possible overloads to `logIMPL`:
 template log*(lineInfo: static InstInfo,
               severity: static[LogLevel],
               eventName: static[string],
               props: varargs[untyped]) {.dirty.} =
+  bind logIMPL, bindSym, brForceOpen
   when loggingEnabled:
-    bind logIMPL, bindSym, brForceOpen
     logIMPL(lineInfo, activeChroniclesStream(),
             Record(activeChroniclesStream()), eventName, severity,
+            bindSym("activeChroniclesScope", brForceOpen), props)
+  else:
+    logIMPL(lineInfo, false, bool, eventName, severity,
             bindSym("activeChroniclesScope", brForceOpen), props)
 
 template log*(lineInfo: static InstInfo,
@@ -352,9 +353,12 @@ template log*(lineInfo: static InstInfo,
               severity: static[LogLevel],
               eventName: static[string],
               props: varargs[untyped]) {.dirty.} =
+  bind logIMPL, bindSym, brForceOpen
   when loggingEnabled:
-    bind logIMPL, bindSym, brForceOpen
     logIMPL(lineInfo, stream, stream.Record, eventName, severity,
+            bindSym("activeChroniclesScope", brForceOpen), props)
+  else:
+    logIMPL(lineInfo, false, bool, eventName, severity,
             bindSym("activeChroniclesScope", brForceOpen), props)
 
 template wrapSideEffects(debug: bool, body: untyped) {.inject.} =


### PR DESCRIPTION
PR #191 practically changed disabled log to do nothing. However, this causes imports or variables used only inside a log to be wrongly flagged as unused.

This change now returns to the earlier behaviour where those arguments are still marked as used. The difference with the original code is that the actual logging part of the code, which never runs when logging disabled, is not compiled in.